### PR TITLE
fix: endpoints for sdk

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,12 +8,19 @@ Python SDK for the SuperMe API. Ask questions to professionals, search expert pe
 pip install superme-sdk
 ```
 
+Or with uv:
+
+```bash
+uv pip install superme-sdk
+```
+
 From source:
 
 ```bash
 git clone https://github.com/superme-ai/superme-sdk.git
 cd superme-sdk
-pip install -e .
+uv sync
+source .venv/bin/activate
 ```
 
 ## Authentication

--- a/superme_sdk/client.py
+++ b/superme_sdk/client.py
@@ -701,7 +701,7 @@ class SuperMeClient:
             Poll :meth:`get_interview_status` for progress.
         """
         resp = self._rest_http.post(
-            "/v3/interview/start-agent",
+            "/api/v3/interview/start-agent",
             json={"role_id": role_id},
         )
         self._check_rest_response(resp)
@@ -713,7 +713,7 @@ class SuperMeClient:
         Returns:
             Dict with ``status``, ``stages``, and other session info.
         """
-        resp = self._rest_http.get(f"/v3/interview/{interview_id}/status")
+        resp = self._rest_http.get(f"/api/v3/interview/{interview_id}/status")
         self._check_rest_response(resp)
         return resp.json()
 
@@ -723,7 +723,7 @@ class SuperMeClient:
         Returns:
             Dict with ``transcript`` list of stages and messages.
         """
-        resp = self._rest_http.get(f"/v3/interview/{interview_id}/transcript")
+        resp = self._rest_http.get(f"/api/v3/interview/{interview_id}/transcript")
         self._check_rest_response(resp)
         return resp.json()
 
@@ -736,12 +736,12 @@ class SuperMeClient:
         uid = self.user_id
         if not uid:
             raise ValueError("Cannot extract user_id from token")
-        resp = self._rest_http.get(f"/v3/interview/by-user/{uid}")
+        resp = self._rest_http.get(f"/api/v3/interview/by-user/{uid}")
         self._check_rest_response(resp)
         return resp.json().get("interviews", [])
 
     def stream_interview(self, interview_id: str):
-        """Stream interview events via SSE from ``GET /v3/interview/{id}/stream``.
+        """Stream interview events via SSE from ``GET /api/v3/interview/{id}/stream``.
 
         Yields dicts parsed from the SSE ``data:`` lines. Each dict has an
         ``event`` key (``"message"``, ``"status"``, or ``"stage_change"``).
@@ -752,7 +752,7 @@ class SuperMeClient:
         terminal = {"completed", "scoring", "scored"}
         with self._rest_http.stream(
             "GET",
-            f"/v3/interview/{interview_id}/stream",
+            f"/api/v3/interview/{interview_id}/stream",
             headers={"Accept-Encoding": "identity"},
             timeout=None,
         ) as resp:
@@ -922,7 +922,7 @@ class SuperMeClient:
             "method": method,
             "params": params,
         }
-        resp = self._rest_http.post("/mcp/", json=payload)
+        resp = self._http.post("/mcp/", json=payload)
         resp.raise_for_status()
 
         ct = resp.headers.get("content-type", "")


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Fix REST and MCP endpoint paths in `SuperMeClient` to include `/api` prefix
- All five REST methods (`start_interview`, `get_interview_status`, `get_interview_transcript`, `list_my_interviews`, `stream_interview`) were calling paths like `/v3/...`; corrected to `/api/v3/...`.
- JSON-RPC POSTs to `/mcp/` now use `self._http` (base URL client) instead of `self._rest_http`, so MCP requests route correctly.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8873e6c.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->