### PR TITLE
fix: add failed and withdrawn terminal statuses to stream_interview SSE

### DIFF
--- a/superme_sdk/services/_interviews.py
+++ b/superme_sdk/services/_interviews.py
@@ -6,7 +6,6 @@ import json
 
 
 class InterviewsMixin:
-
     def start_interview(self, role_id: str) -> dict:
         """Start a background agent interview via REST API.
 
@@ -60,10 +59,10 @@ class InterviewsMixin:
         Yields dicts parsed from the SSE ``data:`` lines. Each dict has an
         ``event`` key (``"message"``, ``"status"``, or ``"stage_change"``).
 
-        Terminal statuses (``completed``, ``scoring``, ``scored``) cause the
-        generator to return.
+        Terminal statuses (``completed``, ``scoring``, ``scored``, ``failed``,
+        ``withdrawn``) cause the generator to return.
         """
-        terminal = {"completed", "scoring", "scored"}
+        terminal = {"completed", "scoring", "scored", "failed", "withdrawn"}
         with self._rest_http.stream(
             "GET",
             f"/api/v3/interview/{interview_id}/stream",


### PR DESCRIPTION
## Summary

- `failed` and `withdrawn` interview statuses were missing from the terminal set in `stream_interview`
- This caused the SSE generator to loop indefinitely when an interview ended abnormally (e.g. agent failure or candidate withdrawal), never yielding a terminal event
- Added both statuses to `terminal` and updated the docstring to document them

## Test plan

- [ ] Confirm that a `{"event": "status", "status": "failed"}` SSE event causes the generator to return
- [ ] Confirm that a `{"event": "status", "status": "withdrawn"}` SSE event causes the generator to return
- [ ] Existing terminal statuses (`completed`, `scoring`, `scored`) still terminate the stream as before


---
[duy 🐨 b04: drift](https://duy.superme.koala.army/task/019da92c-3ebd-7113-bae6-7cf8dc571b04)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `failed` and `withdrawn` as terminal statuses in `InterviewsMixin.stream_interview`
> The `stream_interview` generator in [_interviews.py](https://github.com/superme-ai/superme-sdk/pull/28/files#diff-5440766b0e64bb924d5e25db2d01a4b72154661237aae739bd72a9d60bb8857f) previously only stopped streaming on `completed`, `scoring`, and `scored` statuses. It now also stops on `failed` and `withdrawn`, preventing the SSE stream from continuing after an interview reaches either of these terminal states.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e815af9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->