### PR TITLE
add agentic resume SDK methods

### DIFF
--- a/superme_sdk/client.py
+++ b/superme_sdk/client.py
@@ -9,6 +9,7 @@ import httpx
 
 from ._chat_proxy import Chat, Completions
 from ._http import HttpMixin
+from .services._agentic_resume import AgenticResumeMixin
 from .services._companies import CompaniesMixin
 from .services._content import ContentMixin
 from .services._conversations import ConversationsMixin
@@ -32,6 +33,7 @@ __all__ = [
 
 
 class SuperMeClient(
+    AgenticResumeMixin,
     ConversationsMixin,
     ProfilesMixin,
     GroupsMixin,

--- a/superme_sdk/services/_agentic_resume.py
+++ b/superme_sdk/services/_agentic_resume.py
@@ -1,0 +1,70 @@
+"""Agentic resume methods."""
+
+from __future__ import annotations
+
+
+class AgenticResumeMixin:
+    def get_agentic_resume(self) -> dict:
+        """Fetch the authenticated user's agentic resume.
+
+        Example:
+            ```python
+            resume = client.get_agentic_resume()
+            print(resume["structured_data"])
+            ```
+
+        Returns:
+            Dict with ``structured_data``, ``raw_markdown``, ``html``,
+            ``created_at``, and ``updated_at``.
+            Returns ``{"structured_data": None}`` when no resume exists yet
+            (the backend returns 404 in that case).
+        """
+        resp = self._rest_http.get("/api/v3/agentic-resume")
+        if resp.status_code == 404:
+            return {"structured_data": None}
+        self._check_rest_response(resp)
+        return resp.json()
+
+    def create_agentic_resume_token(self) -> dict:
+        """Generate a one-time upload token for agentic resume ingestion.
+
+        This token is used by external agents (e.g. Claude Code) to upload
+        raw resume markdown.  The workflow is:
+
+        1. Call this method to get a ``token``, ``upload_url``, and
+           ``instructions_url``.
+        2. Give the ``instructions_url`` to an AI agent.
+        3. The agent reads the instructions and POSTs markdown to
+           ``upload_url``.
+        4. The backend synthesises the structured resume in the background.
+
+        Example:
+            ```python
+            result = client.create_agentic_resume_token()
+            print(result["upload_url"])      # one-time upload endpoint
+            print(result["instructions_url"])  # agent instructions markdown
+            ```
+
+        Returns:
+            Dict with ``token``, ``upload_url``, ``instructions_url``,
+            and ``expires_at`` (ISO-8601, 1-hour TTL).
+        """
+        resp = self._rest_http.post("/api/v3/agentic-resume/token")
+        self._check_rest_response(resp)
+        return resp.json()
+
+    def regenerate_agentic_resume(self) -> dict:
+        """Re-synthesize the agentic resume from stored raw markdown.
+
+        Example:
+            ```python
+            result = client.regenerate_agentic_resume()
+            print(result["structured_data"])
+            ```
+
+        Returns:
+            Dict with ``structured_data`` and ``html`` after re-synthesis.
+        """
+        resp = self._rest_http.post("/api/v3/agentic-resume/regenerate")
+        self._check_rest_response(resp)
+        return resp.json()

--- a/superme_sdk/services/_agentic_resume.py
+++ b/superme_sdk/services/_agentic_resume.py
@@ -21,7 +21,13 @@ class AgenticResumeMixin:
         """
         resp = self._rest_http.get("/api/v3/agentic-resume")
         if resp.status_code == 404:
-            return {"structured_data": None}
+            return {
+                "structured_data": None,
+                "raw_markdown": None,
+                "html": None,
+                "created_at": None,
+                "updated_at": None,
+            }
         self._check_rest_response(resp)
         return resp.json()
 

--- a/tests/test_agentic_resume.py
+++ b/tests/test_agentic_resume.py
@@ -1,0 +1,246 @@
+"""Tests for AgenticResumeMixin — unit (mocked) + live e2e.
+
+Unit tests run on every commit with no external dependencies.
+Live tests require SUPERME_API_KEY and run with ``pytest -m live``.
+"""
+
+from __future__ import annotations
+
+import os
+
+import httpx
+import pytest
+import respx
+
+from superme_sdk.client import SuperMeClient
+
+REST_BASE = "https://www.superme.ai"
+FAKE_JWT = "eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoidWlkXzEyMyJ9.sig"
+
+_FAKE_RESUME = {
+    "structured_data": {
+        "prompt_stats": {
+            "metrics": {
+                "total_prompts": 1234,
+                "active_days": 90,
+                "usage_rate": "78%",
+                "sessions": 42,
+                "longest_streak": 14,
+            },
+        },
+        "shipped": {
+            "product_context": "Built core platform",
+            "domains": [{"name": "API", "prose": "REST API layer"}],
+            "tech_stack": [{"layer": "backend", "tech": "Python"}],
+        },
+        "notable_sessions": [
+            {"name": "Big refactor", "date": "2025-04-01", "messages": 50, "hours": 3.0, "what_happened": "Rewrote auth"}
+        ],
+        "prompt_style": {
+            "traits": [{"label": "Direct", "evidence": "Often skips pleasantries"}],
+            "overall": "Concise and task-oriented",
+        },
+    },
+    "raw_markdown": "# Raw data\nSome content",
+    "html": "<html>...</html>",
+    "created_at": "2025-04-01T10:00:00Z",
+    "updated_at": "2025-04-18T10:00:00Z",
+}
+
+
+# ---------------------------------------------------------------------------
+# Contract tests
+# ---------------------------------------------------------------------------
+
+
+class TestContractAllMethodsExist:
+    def test_all_methods_present(self):
+        expected = [
+            "get_agentic_resume",
+            "regenerate_agentic_resume",
+            "create_agentic_resume_token",
+        ]
+        for name in expected:
+            assert hasattr(SuperMeClient, name), f"SuperMeClient missing method: {name}"
+            assert callable(getattr(SuperMeClient, name))
+
+
+# ---------------------------------------------------------------------------
+# get_agentic_resume
+# ---------------------------------------------------------------------------
+
+
+class TestGetAgenticResume:
+    @respx.mock
+    def test_get_resume_returns_data(self):
+        respx.get(f"{REST_BASE}/api/v3/agentic-resume").mock(
+            return_value=httpx.Response(200, json=_FAKE_RESUME)
+        )
+        client = SuperMeClient(api_key=FAKE_JWT)
+        result = client.get_agentic_resume()
+        assert result["structured_data"] is not None
+        assert result["raw_markdown"] == "# Raw data\nSome content"
+        client.close()
+
+    @respx.mock
+    def test_get_resume_404_returns_empty(self):
+        """404 means no resume exists yet — should return {structured_data: None}."""
+        respx.get(f"{REST_BASE}/api/v3/agentic-resume").mock(
+            return_value=httpx.Response(404, json={"detail": "not found"})
+        )
+        client = SuperMeClient(api_key=FAKE_JWT)
+        result = client.get_agentic_resume()
+        assert result == {"structured_data": None}
+        client.close()
+
+    @respx.mock
+    def test_get_resume_5xx_raises(self):
+        respx.get(f"{REST_BASE}/api/v3/agentic-resume").mock(
+            return_value=httpx.Response(500, json={"error": "server error"})
+        )
+        client = SuperMeClient(api_key=FAKE_JWT)
+        with pytest.raises(RuntimeError):
+            client.get_agentic_resume()
+        client.close()
+
+    @respx.mock
+    def test_get_resume_calls_correct_url(self):
+        route = respx.get(f"{REST_BASE}/api/v3/agentic-resume").mock(
+            return_value=httpx.Response(200, json=_FAKE_RESUME)
+        )
+        client = SuperMeClient(api_key=FAKE_JWT)
+        client.get_agentic_resume()
+        assert route.called
+        client.close()
+
+
+# ---------------------------------------------------------------------------
+# regenerate_agentic_resume
+# ---------------------------------------------------------------------------
+
+
+class TestRegenerateAgenticResume:
+    @respx.mock
+    def test_regenerate_returns_structured_data(self):
+        payload = {"structured_data": _FAKE_RESUME["structured_data"], "html": "<html/>"}
+        respx.post(f"{REST_BASE}/api/v3/agentic-resume/regenerate").mock(
+            return_value=httpx.Response(200, json=payload)
+        )
+        client = SuperMeClient(api_key=FAKE_JWT)
+        result = client.regenerate_agentic_resume()
+        assert result["structured_data"] is not None
+        assert result["html"] == "<html/>"
+        client.close()
+
+    @respx.mock
+    def test_regenerate_404_raises(self):
+        """404 from regenerate means no raw markdown stored — should raise."""
+        respx.post(f"{REST_BASE}/api/v3/agentic-resume/regenerate").mock(
+            return_value=httpx.Response(404, json={"detail": "not found"})
+        )
+        client = SuperMeClient(api_key=FAKE_JWT)
+        with pytest.raises(RuntimeError):
+            client.regenerate_agentic_resume()
+        client.close()
+
+    @respx.mock
+    def test_regenerate_calls_correct_url(self):
+        route = respx.post(f"{REST_BASE}/api/v3/agentic-resume/regenerate").mock(
+            return_value=httpx.Response(200, json={"structured_data": {}, "html": ""})
+        )
+        client = SuperMeClient(api_key=FAKE_JWT)
+        client.regenerate_agentic_resume()
+        assert route.called
+        client.close()
+
+
+# ---------------------------------------------------------------------------
+# create_agentic_resume_token
+# ---------------------------------------------------------------------------
+
+
+class TestCreateAgenticResumeToken:
+    @respx.mock
+    def test_create_token_returns_urls(self):
+        payload = {
+            "token": "tok_abc123",
+            "upload_url": "https://www.superme.ai/api/v3/agentic-resume/upload/tok_abc123",
+            "instructions_url": "https://www.superme.ai/api/v3/agentic-resume/instructions/tok_abc123",
+            "expires_at": "2025-04-18T11:00:00Z",
+        }
+        respx.post(f"{REST_BASE}/api/v3/agentic-resume/token").mock(
+            return_value=httpx.Response(200, json=payload)
+        )
+        client = SuperMeClient(api_key=FAKE_JWT)
+        result = client.create_agentic_resume_token()
+        assert result["token"] == "tok_abc123"
+        assert "upload_url" in result
+        assert "instructions_url" in result
+        assert "expires_at" in result
+        client.close()
+
+    @respx.mock
+    def test_create_token_calls_correct_url(self):
+        route = respx.post(f"{REST_BASE}/api/v3/agentic-resume/token").mock(
+            return_value=httpx.Response(200, json={"token": "t", "upload_url": "u", "instructions_url": "i", "expires_at": "e"})
+        )
+        client = SuperMeClient(api_key=FAKE_JWT)
+        client.create_agentic_resume_token()
+        assert route.called
+        client.close()
+
+    @respx.mock
+    def test_create_token_401_raises(self):
+        respx.post(f"{REST_BASE}/api/v3/agentic-resume/token").mock(
+            return_value=httpx.Response(401, json={"error": "unauthorized"})
+        )
+        client = SuperMeClient(api_key=FAKE_JWT)
+        with pytest.raises(RuntimeError):
+            client.create_agentic_resume_token()
+        client.close()
+
+
+# ---------------------------------------------------------------------------
+# Live e2e tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def live_client():
+    key = os.getenv("SUPERME_API_KEY", "")
+    if not key:
+        pytest.skip("SUPERME_API_KEY not set")
+    client = SuperMeClient(api_key=key)
+    yield client
+    client.close()
+
+
+@pytest.mark.live
+def test_live_get_agentic_resume(live_client):
+    """get_agentic_resume returns a dict (may be empty if no resume exists)."""
+    result = live_client.get_agentic_resume()
+    assert isinstance(result, dict)
+    assert "structured_data" in result
+
+
+@pytest.mark.live
+def test_live_create_agentic_resume_token(live_client):
+    """create_agentic_resume_token returns token + URLs."""
+    result = live_client.create_agentic_resume_token()
+    assert "token" in result
+    assert "upload_url" in result
+    assert "instructions_url" in result
+    assert "expires_at" in result
+
+
+@pytest.mark.live
+def test_live_regenerate_requires_existing_data(live_client):
+    """regenerate raises if no resume exists, or returns structured_data if one does."""
+    resume = live_client.get_agentic_resume()
+    if not resume.get("structured_data"):
+        with pytest.raises((RuntimeError, Exception)):
+            live_client.regenerate_agentic_resume()
+    else:
+        result = live_client.regenerate_agentic_resume()
+        assert isinstance(result, dict)
+        assert "structured_data" in result

--- a/tests/test_agentic_resume.py
+++ b/tests/test_agentic_resume.py
@@ -84,13 +84,17 @@ class TestGetAgenticResume:
 
     @respx.mock
     def test_get_resume_404_returns_empty(self):
-        """404 means no resume exists yet — should return {structured_data: None}."""
+        """404 means no resume exists yet — should return a full sentinel dict."""
         respx.get(f"{REST_BASE}/api/v3/agentic-resume").mock(
             return_value=httpx.Response(404, json={"detail": "not found"})
         )
         client = SuperMeClient(api_key=FAKE_JWT)
         result = client.get_agentic_resume()
-        assert result == {"structured_data": None}
+        assert result["structured_data"] is None
+        assert result["raw_markdown"] is None
+        assert result["html"] is None
+        assert result["created_at"] is None
+        assert result["updated_at"] is None
         client.close()
 
     @respx.mock
@@ -137,6 +141,16 @@ class TestRegenerateAgenticResume:
         """404 from regenerate means no raw markdown stored — should raise."""
         respx.post(f"{REST_BASE}/api/v3/agentic-resume/regenerate").mock(
             return_value=httpx.Response(404, json={"detail": "not found"})
+        )
+        client = SuperMeClient(api_key=FAKE_JWT)
+        with pytest.raises(RuntimeError):
+            client.regenerate_agentic_resume()
+        client.close()
+
+    @respx.mock
+    def test_regenerate_5xx_raises(self):
+        respx.post(f"{REST_BASE}/api/v3/agentic-resume/regenerate").mock(
+            return_value=httpx.Response(500, json={"error": "synthesis failed"})
         )
         client = SuperMeClient(api_key=FAKE_JWT)
         with pytest.raises(RuntimeError):


### PR DESCRIPTION
## Summary
- Adds `AgenticResumeMixin` with `get_agentic_resume()`, `regenerate_agentic_resume()`, and `create_agentic_resume_token()`
- `get_agentic_resume()` treats 404 as "no resume yet" (returns `{structured_data: None}`) rather than raising
- `create_agentic_resume_token()` generates a one-time upload token for the agent ingestion flow
- Full unit test coverage with respx mocks (11 new unit tests + 3 live tests)

## Test plan
- [ ] `pytest tests/test_agentic_resume.py` — all unit tests pass
- [ ] `pytest -m live tests/test_agentic_resume.py` — requires `SUPERME_API_KEY`

---
[duy 🐨 19d: https://github.com/superme-ai/superme-cli/](https://duy.superme.koala.army/task/019daa38-758e-7779-8502-f17586e6b19d)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add agentic resume SDK methods to `SuperMeClient`
> - Adds [`AgenticResumeMixin`](https://github.com/superme-ai/superme-sdk/pull/33/files#diff-b2ef8a4c2b3d633898200f78b8b3225858b00594f230389c985cdbd0ee1d80f1) with three methods: `get_agentic_resume` (GET `/api/v3/agentic-resume`), `create_agentic_resume_token` (POST `/api/v3/agentic-resume/token`), and `regenerate_agentic_resume` (POST `/api/v3/agentic-resume/regenerate`).
> - Mixes `AgenticResumeMixin` into [`SuperMeClient`](https://github.com/superme-ai/superme-sdk/pull/33/files#diff-5071874953f51eda83589e13482236447d24f88ff0f88dec6b1304f5dd78ba78) so all three methods are available on the client.
> - `get_agentic_resume` returns a sentinel dict with all fields set to `None` on 404; all other non-2xx responses raise via `_check_rest_response`.
> - Adds unit, contract, and live e2e tests in [`tests/test_agentic_resume.py`](https://github.com/superme-ai/superme-sdk/pull/33/files#diff-995d939e407bdd1a9aab6c676a20367fe9b81ebed0ae0382f23c837cbfc9fcf0); e2e tests are gated by `SUPERME_API_KEY`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e57c273.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->