### PR TITLE
fix: docs CI pip install

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -18,6 +18,6 @@ jobs:
         with:
           python-version: "3.11"
       - name: Install docs dependencies
-        run: uv pip install --system -r docs/requirements.txt
+        run: pip install -r docs/requirements.txt
       - name: Deploy to docs branch
         run: mkdocs gh-deploy --force --remote-branch docs


### PR DESCRIPTION
Fixes `uv pip install --system` error — no system Python found in runner. Use `pip` directly since `setup-uv` puts Python 3.11 in PATH.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix docs CI dependency install by switching from `uv pip` to `pip`
> The [docs.yml](https://github.com/superme-ai/superme-sdk/pull/35/files#diff-9cf2000c53760d837a449f874e53f792819108d3a4bf346336d0f7d082deae2c) `Install docs dependencies` step was using `uv pip install --system`, which was failing in CI. It now uses standard `pip install` instead.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6233388.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->