### PR TITLE
fix: swap setup-uv for setup-python in docs workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -18,6 +18,6 @@ jobs:
         with:
           python-version: "3.11"
       - name: Install docs dependencies
-        run: uv pip install --system -r docs/requirements.txt
+        run: pip install -r docs/requirements.txt
       - name: Deploy to docs branch
         run: mkdocs gh-deploy --force --remote-branch docs

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+      - uses: actions/setup-python@v5
         with:
           python-version: "3.11"
       - name: Install docs dependencies


### PR DESCRIPTION
Fixes post-job cache error from `setup-uv` — since we use `pip` and not `uv` in this workflow, `setup-uv` has nothing to cache and errors on cleanup.

Swaps it for `actions/setup-python` which is all we need.

**To test before merging:** Actions → Docs → Run workflow → pick this branch.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace `setup-uv` with `setup-python` in docs workflow
> Switches the [docs.yml](https://github.com/superme-ai/superme-sdk/pull/36/files#diff-9cf2000c53760d837a449f874e53f792819108d3a4bf346336d0f7d082deae2c) deploy job from `astral-sh/setup-uv` to `actions/setup-python@v5` and updates the dependency install command from `uv pip install --system` to plain `pip install`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fa144e7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->