### PR TITLE
chore: Remove documentation link from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,7 @@
 
 Python SDK for the SuperMe API. Ask questions to professionals, search expert perspectives, manage your knowledge library, and interact via MCP.
 
-## Documentation
 
-Live at: https://superme-ai.github.io/superme-sdk/
 
 ## Installation
 


### PR DESCRIPTION
Removed documentation link from README.
It give a warning due to URL impersonation guard, will add back after setting a domain for this.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove documentation link from README
> Removes the `## Documentation` section and its link to the hosted docs site from [README.md](https://github.com/superme-ai/superme-sdk/pull/38/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2eb7e60.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->