### PR TITLE
ci: add tag-triggered GitHub release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,24 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          python-version: "3.11"
+      - name: Build sdist and wheel
+        run: uv build
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: dist/*
+          generate_release_notes: true


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/release.yml` that runs on `v*` tag pushes
- Builds sdist + wheel with `uv build` and uploads them to a GitHub Release with auto-generated notes

## How to cut a release
```bash
git tag v0.1.0
git push --tags
```

## Next steps
Once this is merged and a tag is cut, update `superme-cli/pyproject.toml` to pin:
```toml
superme-sdk = { git = "https://github.com/superme-ai/superme-sdk", tag = "v0.1.0" }
```
This prevents CLI breakage from unreviewed SDK changes landing on main.

---
[duy 🐨 ea4: github release cli, private](https://duy.superme.koala.army/task/019dafcf-d831-7779-8503-854a79349ea4)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add tag-triggered GitHub Actions release workflow
> Adds [release.yml](.github/workflows/release.yml), a workflow that triggers on `v*` tag pushes, builds a Python sdist and wheel via `uv build`, and publishes a GitHub Release with auto-generated notes and the `dist/*` artifacts attached.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 87706f3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->