### PR TITLE
docs: add Library section to API reference

### DIFF
--- a/docs/api/services/library.md
+++ b/docs/api/services/library.md
@@ -1,0 +1,3 @@
+# Library
+
+::: superme_sdk.services._library.LibraryMixin

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -55,5 +55,6 @@ nav:
     - Companies & Roles: api/services/companies.md
     - Interviews: api/services/interviews.md
     - Content: api/services/content.md
+    - Library: api/services/library.md
     - Social: api/services/social.md
     - OpenAI-compatible chat: api/chat.md


### PR DESCRIPTION
## Summary

- Add `docs/api/services/library.md` — auto-generates from `LibraryMixin` docstrings
- Wire `Library` into `mkdocs.yml` nav

Pure docs change, no logic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Library section to the API reference documentation
> Adds a new [library.md](https://github.com/superme-ai/superme-sdk/pull/43/files#diff-3a6e555dfadd09953e009970624a3e3367b5e22feacc2b71f587675bc71523b3) page that renders API docs for `superme_sdk.services._library.LibraryMixin`, and registers it under the API Reference section in [mkdocs.yml](https://github.com/superme-ai/superme-sdk/pull/43/files#diff-98d0f806abc9af24e6a7c545d3d77e8f9ad57643e27211d7a7b896113e420ed2).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 32af1eb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->