### PR TITLE
docs: add CNAME for sdkdocs.superme.ai custom domain

### DIFF
--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,0 +1,1 @@
+sdkdocs.superme.ai

--- a/docs/api/services/library.md
+++ b/docs/api/services/library.md
@@ -1,0 +1,3 @@
+# Library
+
+::: superme_sdk.services._library.LibraryMixin

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -55,5 +55,6 @@ nav:
     - Companies & Roles: api/services/companies.md
     - Interviews: api/services/interviews.md
     - Content: api/services/content.md
+    - Library: api/services/library.md
     - Social: api/services/social.md
     - OpenAI-compatible chat: api/chat.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,6 @@
 site_name: SuperMe SDK
 site_description: Python SDK for the SuperMe AI API
-site_url: https://superme-ai.github.io/superme-sdk/
+site_url: https://sdkdocs.superme.ai/
 repo_url: https://github.com/superme-ai/superme-sdk
 repo_name: superme-ai/superme-sdk
 


### PR DESCRIPTION
## Summary
- Add `docs/CNAME` with `sdkdocs.superme.ai` — MkDocs copies it on every `gh-deploy`, so the custom domain survives redeployments
- Update `site_url` in `mkdocs.yml` to `https://sdkdocs.superme.ai/` so generated links are correct

## Test plan
- [ ] Merge → CI docs workflow runs → check `docs` branch contains `CNAME`
- [ ] Visit `https://sdkdocs.superme.ai/` resolves (requires DNS CNAME record `sdkdocs.superme.ai → superme-ai.github.io` and custom domain set in repo Settings → Pages)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add CNAME for sdkdocs.superme.ai custom domain and Library API docs
> - Adds a [CNAME](https://github.com/superme-ai/superme-sdk/pull/44/files#diff-00d22ea612a748d8ddd4e5bf6a203591ae83569e7b16f50a11fa6d31a5bedddd) file pointing to `sdkdocs.superme.ai` to configure a custom domain for the documentation site.
> - Updates `site_url` in [mkdocs.yml](https://github.com/superme-ai/superme-sdk/pull/44/files#diff-98d0f806abc9af24e6a7c545d3d77e8f9ad57643e27211d7a7b896113e420ed2) to match the new domain.
> - Adds a [Library API reference page](https://github.com/superme-ai/superme-sdk/pull/44/files#diff-3a6e555dfadd09953e009970624a3e3367b5e22feacc2b71f587675bc71523b3) that auto-documents `superme_sdk.services._library.LibraryMixin`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized faf44de.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->