### PR TITLE
feat: add working-groups SDK methods (sync + async)

### DIFF
--- a/superme_sdk/client.py
+++ b/superme_sdk/client.py
@@ -18,10 +18,12 @@ from .services._interviews import InterviewsMixin
 from .services._library import LibraryMixin
 from .services._profiles import ProfilesMixin
 from .services._social import SocialMixin
+from .services._working_groups import WorkingGroupsMixin
 from .services.aio._agentic_resume import AsyncAgenticResumeMixin
 from .services.aio._conversations import AsyncConversationsMixin
 from .services.aio._groups import AsyncGroupsMixin
 from .services.aio._interviews import AsyncInterviewsMixin
+from .services.aio._working_groups import AsyncWorkingGroupsMixin
 from .models import ChatCompletion, Choice, Message, Usage
 
 # Re-export for backward compatibility:
@@ -87,6 +89,7 @@ class SuperMeClient(
     LibraryMixin,
     ContentMixin,
     SocialMixin,
+    WorkingGroupsMixin,
     HttpMixin,
 ):
     """SuperMe API client with OpenAI-compatible interface.
@@ -183,6 +186,7 @@ class AsyncSuperMeClient(
     AsyncConversationsMixin,
     AsyncGroupsMixin,
     AsyncInterviewsMixin,
+    AsyncWorkingGroupsMixin,
     AsyncHttpMixin,
     # HttpMixin provides _check_rest_response, _parse_sse_json, _decode_jwt via MRO
     HttpMixin,

--- a/superme_sdk/services/_working_groups.py
+++ b/superme_sdk/services/_working_groups.py
@@ -1,0 +1,129 @@
+"""Working group methods — sync.
+
+A *working group* is a saved set of SuperMe users (e.g. a project team or advisory
+board) that the owner has assembled for repeated reference. Members are SuperMe
+users — resolve names via :meth:`find_user_by_name` first.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+
+class WorkingGroupsMixin:
+    def list_working_groups(self) -> list[dict]:
+        """List your working groups, most recently used first.
+
+        Example:
+            ```python
+            for g in client.list_working_groups():
+                print(g["handle"], g["name"], len(g["members"]))
+            ```
+
+        Returns:
+            List of working-group dicts. Each has ``id``, ``handle``, ``name``,
+            ``description``, ``members`` (list of ``{user_id, name}``), and
+            ``created_at`` / ``updated_at`` / ``last_used_at`` timestamps.
+        """
+        result = self._mcp_tool_call("list_working_groups", {})
+        if isinstance(result, dict):
+            groups = result.get("groups", [])
+            return groups if isinstance(groups, list) else []
+        return []
+
+    def get_working_group(self, group_id: str) -> Optional[dict]:
+        """Get a single working group by ID.
+
+        Example:
+            ```python
+            group = client.get_working_group("abc123")
+            for m in group["members"]:
+                print(m["user_id"], m["name"])
+            ```
+
+        Returns:
+            Working-group dict, or ``None`` if no group with that ID exists.
+        """
+        result = self._mcp_tool_call("get_working_group", {"group_id": group_id})
+        if isinstance(result, dict) and "error" not in result:
+            return result
+        return None
+
+    def create_working_group(
+        self,
+        name: str,
+        handle: str,
+        *,
+        description: str = "",
+        members: Optional[list[dict]] = None,
+    ) -> dict:
+        """Create a new working group.
+
+        Example:
+            ```python
+            group = client.create_working_group(
+                name="Growth advisory board",
+                handle="growth-board",
+                members=[
+                    {"user_id": "abc123", "name": "Casey Winters"},
+                    {"user_id": "def456", "name": "Elena Verna"},
+                ],
+            )
+            print(group["id"])
+            ```
+
+        Args:
+            name: Human-readable name.
+            handle: Short unique handle within your account.
+            description: Optional longer description.
+            members: Initial member list, each entry ``{"user_id", "name"}``.
+                Resolve names to user_ids via :meth:`find_user_by_name` first.
+
+        Returns:
+            The created working-group dict (or ``{"error": ...}`` if the handle
+            is already taken).
+        """
+        args: dict[str, Any] = {"name": name, "handle": handle}
+        if description:
+            args["description"] = description
+        if members is not None:
+            args["members"] = members
+        return self._mcp_tool_call("create_working_group", args)
+
+    def update_working_group(
+        self,
+        group_id: str,
+        *,
+        name: Optional[str] = None,
+        handle: Optional[str] = None,
+        description: Optional[str] = None,
+        members: Optional[list[dict]] = None,
+    ) -> dict:
+        """Update an existing working group you own.
+
+        Only the fields you pass are changed. ``members`` is a full replacement —
+        pass the complete desired member list, not a delta.
+
+        Example:
+            ```python
+            client.update_working_group(
+                "abc123",
+                name="Growth advisors (Q2)",
+                members=[{"user_id": "abc", "name": "Casey"}],
+            )
+            ```
+
+        Returns:
+            The updated working-group dict, or ``{"error": ...}`` on conflict /
+            not-found.
+        """
+        args: dict[str, Any] = {"group_id": group_id}
+        if name is not None:
+            args["name"] = name
+        if handle is not None:
+            args["handle"] = handle
+        if description is not None:
+            args["description"] = description
+        if members is not None:
+            args["members"] = members
+        return self._mcp_tool_call("update_working_group", args)

--- a/superme_sdk/services/aio/__init__.py
+++ b/superme_sdk/services/aio/__init__.py
@@ -4,10 +4,12 @@ from ._agentic_resume import AsyncAgenticResumeMixin
 from ._conversations import AsyncConversationsMixin
 from ._groups import AsyncGroupsMixin
 from ._interviews import AsyncInterviewsMixin
+from ._working_groups import AsyncWorkingGroupsMixin
 
 __all__ = [
     "AsyncAgenticResumeMixin",
     "AsyncConversationsMixin",
     "AsyncGroupsMixin",
     "AsyncInterviewsMixin",
+    "AsyncWorkingGroupsMixin",
 ]

--- a/superme_sdk/services/aio/_working_groups.py
+++ b/superme_sdk/services/aio/_working_groups.py
@@ -1,0 +1,71 @@
+"""Working group methods — async.
+
+A *working group* is a saved set of SuperMe users (e.g. a project team or advisory
+board) that the owner has assembled for repeated reference. Members are SuperMe
+users — resolve names via :meth:`find_user_by_name` first.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+
+class AsyncWorkingGroupsMixin:
+    """Async variants of :class:`~superme_sdk.services._working_groups.WorkingGroupsMixin`."""
+
+    async def list_working_groups(self) -> list[dict]:
+        """List your working groups, most recently used first (async)."""
+        result = await self._async_mcp_tool_call("list_working_groups", {})
+        if isinstance(result, dict):
+            groups = result.get("groups", [])
+            return groups if isinstance(groups, list) else []
+        return []
+
+    async def get_working_group(self, group_id: str) -> Optional[dict]:
+        """Get a single working group by ID (async)."""
+        result = await self._async_mcp_tool_call(
+            "get_working_group", {"group_id": group_id}
+        )
+        if isinstance(result, dict) and "error" not in result:
+            return result
+        return None
+
+    async def create_working_group(
+        self,
+        name: str,
+        handle: str,
+        *,
+        description: str = "",
+        members: Optional[list[dict]] = None,
+    ) -> dict:
+        """Create a new working group (async)."""
+        args: dict[str, Any] = {"name": name, "handle": handle}
+        if description:
+            args["description"] = description
+        if members is not None:
+            args["members"] = members
+        return await self._async_mcp_tool_call("create_working_group", args)
+
+    async def update_working_group(
+        self,
+        group_id: str,
+        *,
+        name: Optional[str] = None,
+        handle: Optional[str] = None,
+        description: Optional[str] = None,
+        members: Optional[list[dict]] = None,
+    ) -> dict:
+        """Update an existing working group (async).
+
+        ``members`` is a full replacement — pass the complete desired member list.
+        """
+        args: dict[str, Any] = {"group_id": group_id}
+        if name is not None:
+            args["name"] = name
+        if handle is not None:
+            args["handle"] = handle
+        if description is not None:
+            args["description"] = description
+        if members is not None:
+            args["members"] = members
+        return await self._async_mcp_tool_call("update_working_group", args)

--- a/tests/test_working_groups.py
+++ b/tests/test_working_groups.py
@@ -1,0 +1,111 @@
+"""Tests for working-group SDK methods."""
+
+import json
+
+import httpx
+import pytest
+import respx
+
+from superme_sdk.client import SuperMeClient
+
+MCP_BASE = "https://mcp.superme.ai"
+
+GROUP = {
+    "id": "wg_abc",
+    "owner_user_id": "user_1",
+    "handle": "growth-board",
+    "name": "Growth advisory board",
+    "description": "",
+    "members": [{"user_id": "user_2", "name": "Casey"}],
+    "created_at": "2026-04-30T00:00:00+00:00",
+    "updated_at": "2026-04-30T00:00:00+00:00",
+    "last_used_at": None,
+}
+
+
+def _mock_mcp(payload: dict):
+    """Mock POST / returning the given payload as the tool result."""
+    rpc = {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "result": {"content": [{"type": "text", "text": json.dumps(payload)}]},
+    }
+    return respx.post(f"{MCP_BASE}/mcp/").mock(
+        return_value=httpx.Response(200, json=rpc)
+    )
+
+
+@respx.mock
+def test_list_working_groups_returns_list():
+    _mock_mcp({"groups": [GROUP], "count": 1})
+    client = SuperMeClient(api_key="tok")
+    result = client.list_working_groups()
+    assert result == [GROUP]
+    client.close()
+
+
+@respx.mock
+def test_list_working_groups_empty():
+    _mock_mcp({"groups": [], "count": 0})
+    client = SuperMeClient(api_key="tok")
+    assert client.list_working_groups() == []
+    client.close()
+
+
+@respx.mock
+def test_get_working_group_returns_dict():
+    _mock_mcp(GROUP)
+    client = SuperMeClient(api_key="tok")
+    result = client.get_working_group("wg_abc")
+    assert result == GROUP
+    client.close()
+
+
+@respx.mock
+def test_get_working_group_returns_none_on_error():
+    _mock_mcp({"error": "Working group not found: wg_missing"})
+    client = SuperMeClient(api_key="tok")
+    assert client.get_working_group("wg_missing") is None
+    client.close()
+
+
+@respx.mock
+def test_create_working_group_returns_group():
+    route = _mock_mcp(GROUP)
+    client = SuperMeClient(api_key="tok")
+    result = client.create_working_group(
+        name="Growth advisory board",
+        handle="growth-board",
+        members=[{"user_id": "user_2", "name": "Casey"}],
+    )
+    assert result == GROUP
+    # Verify the tool name + arguments
+    body = json.loads(route.calls[0].request.content)
+    assert body["params"]["name"] == "create_working_group"
+    args = body["params"]["arguments"]
+    assert args["name"] == "Growth advisory board"
+    assert args["handle"] == "growth-board"
+    assert args["members"] == [{"user_id": "user_2", "name": "Casey"}]
+    client.close()
+
+
+@respx.mock
+def test_update_working_group_only_passes_provided_fields():
+    route = _mock_mcp(GROUP)
+    client = SuperMeClient(api_key="tok")
+    client.update_working_group("wg_abc", name="renamed")
+    body = json.loads(route.calls[0].request.content)
+    args = body["params"]["arguments"]
+    assert args == {"group_id": "wg_abc", "name": "renamed"}
+    client.close()
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_async_list_working_groups():
+    from superme_sdk.client import AsyncSuperMeClient
+
+    _mock_mcp({"groups": [GROUP], "count": 1})
+    async with AsyncSuperMeClient(api_key="tok") as client:
+        result = await client.list_working_groups()
+        assert result == [GROUP]


### PR DESCRIPTION
## Summary

Backend PR superme-ai/superme-backend#3498 added working_group MCP tools. Expose them as first-class client methods so callers don't have to drop down to \`client.low_level.tool_call\`:

- \`list_working_groups()\`
- \`get_working_group(group_id)\`
- \`create_working_group(name, handle, *, description, members)\`
- \`update_working_group(group_id, *, name, handle, description, members)\`

Sync methods on \`SuperMeClient\` via \`WorkingGroupsMixin\`; async equivalents on \`AsyncSuperMeClient\` via \`AsyncWorkingGroupsMixin\`. Mirrors the existing companies/groups mixin pattern. Delete is intentionally not exposed (matches the backend tool surface).

## Test plan

- [x] \`make lint\` clean
- [x] \`make test\` — 131 passed (124 baseline + 7 new in \`tests/test_working_groups.py\`)
- [x] Smoke against staging: \`client.list_working_groups()\` after create

---
[robin 🐨 256: I want agents using our MCP to be able to create update and read workin…](https://robin.superme.koala.army/task/019ddf09-c79b-7dd6-bb69-263e2281d256)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add working-groups methods to sync and async SDK clients
> - Adds `WorkingGroupsMixin` and `AsyncWorkingGroupsMixin` in [_working_groups.py](https://github.com/superme-ai/superme-sdk/pull/47/files#diff-dc44a1d4cf06f1dc98b374ff18d4c39dc8ee7eaed1e0e4675038a4c796632117) and [aio/_working_groups.py](https://github.com/superme-ai/superme-sdk/pull/47/files#diff-ecb5ca97f15bf2aa2b402286d4e789bf43cce7ebb2acf0b479f0ffc411b20fb8), implementing `list_working_groups`, `get_working_group`, `create_working_group`, and `update_working_group`.
> - Both mixins delegate to named MCP tool calls and normalize return values (`[]` for empty list results, `None` on error responses).
> - Mixed into `SuperMeClient` and `AsyncSuperMeClient` in [client.py](https://github.com/superme-ai/superme-sdk/pull/47/files#diff-5071874953f51eda83589e13482236447d24f88ff0f88dec6b1304f5dd78ba78) via multiple inheritance.
> - New tests in [test_working_groups.py](https://github.com/superme-ai/superme-sdk/pull/47/files#diff-864e18b19cf23db8371ed08d0c7959df16b3a6c0d9246a06d69d53f26acd2f98) cover list, get, create, and update for both sync and async clients.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 679208e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->