### PR TITLE
fix: remove unused json import in _conversations.py

### DIFF
--- a/superme_sdk/services/_conversations.py
+++ b/superme_sdk/services/_conversations.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import json
 import warnings
 from typing import Any, Generator, Optional
 


### PR DESCRIPTION
Pre-existing lint error — unused `import json` in `_conversations.py`.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove unused `json` import from `_conversations.py`
> Cleans up an unused `json` import in [_conversations.py](https://github.com/superme-ai/superme-sdk/pull/50/files#diff-711de642151772b2798a22a719c73a9534dfe1c3b3d84f1ded052f9f4d66b630). No functional behavior is changed.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b26657d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Cleaned up unused imports in internal dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->