### PR TITLE
feat: separate NDJSON transport from SSE; fix agent/group streaming

### DIFF
--- a/superme_sdk/_transport/__init__.py
+++ b/superme_sdk/_transport/__init__.py
@@ -1,14 +1,5 @@
 """Low-level HTTP, SSE, NDJSON, and protocol transport internals."""
 
 from ._http import HttpMixin, _decode_jwt
-from ._ndjson import aiter_ndjson_lines, iter_ndjson_lines
-from ._sse import aiter_sse_lines, iter_sse_lines
 
-__all__ = [
-    "HttpMixin",
-    "_decode_jwt",
-    "iter_sse_lines",
-    "aiter_sse_lines",
-    "iter_ndjson_lines",
-    "aiter_ndjson_lines",
-]
+__all__ = ["HttpMixin", "_decode_jwt"]

--- a/superme_sdk/_transport/__init__.py
+++ b/superme_sdk/_transport/__init__.py
@@ -1,6 +1,14 @@
-"""Low-level HTTP, SSE, and protocol transport internals."""
+"""Low-level HTTP, SSE, NDJSON, and protocol transport internals."""
 
 from ._http import HttpMixin, _decode_jwt
+from ._ndjson import aiter_ndjson_lines, iter_ndjson_lines
 from ._sse import aiter_sse_lines, iter_sse_lines
 
-__all__ = ["HttpMixin", "_decode_jwt", "iter_sse_lines", "aiter_sse_lines"]
+__all__ = [
+    "HttpMixin",
+    "_decode_jwt",
+    "iter_sse_lines",
+    "aiter_sse_lines",
+    "iter_ndjson_lines",
+    "aiter_ndjson_lines",
+]

--- a/superme_sdk/_transport/_http.py
+++ b/superme_sdk/_transport/_http.py
@@ -8,7 +8,7 @@ from typing import Any, Generator, Optional
 
 import httpx
 
-from ._sse import iter_sse_lines
+from ._ndjson import iter_ndjson_lines
 from ..exceptions import APIError, AuthError, MCPError, NotFoundError, RateLimitError
 from ..models import StreamEvent
 
@@ -66,7 +66,7 @@ class HttpMixin:
                 resp.read()
             self._check_rest_response(resp)
 
-            for line in iter_sse_lines(resp):
+            for line in iter_ndjson_lines(resp):
                 try:
                     obj = json.loads(line)
                 except (json.JSONDecodeError, ValueError):

--- a/superme_sdk/_transport/_ndjson.py
+++ b/superme_sdk/_transport/_ndjson.py
@@ -23,13 +23,11 @@ def iter_ndjson_lines(response: httpx.Response) -> Generator[str, None, None]:
         while "\n" in buf:
             line, buf = buf.split("\n", 1)
             line = line.strip()
-            if not line or line.startswith(":"):
+            if not line:
                 continue
             yield line
     if buf.strip():
-        line = buf.strip()
-        if not line.startswith(":"):
-            yield line
+        yield buf.strip()
 
 
 async def aiter_ndjson_lines(response: httpx.Response) -> AsyncGenerator[str, None]:
@@ -40,10 +38,8 @@ async def aiter_ndjson_lines(response: httpx.Response) -> AsyncGenerator[str, No
         while "\n" in buf:
             line, buf = buf.split("\n", 1)
             line = line.strip()
-            if not line or line.startswith(":"):
+            if not line:
                 continue
             yield line
     if buf.strip():
-        line = buf.strip()
-        if not line.startswith(":"):
-            yield line
+        yield buf.strip()

--- a/superme_sdk/_transport/_ndjson.py
+++ b/superme_sdk/_transport/_ndjson.py
@@ -1,0 +1,49 @@
+"""NDJSON (newline-delimited JSON) line-parsing utilities.
+
+Yields raw JSON lines from ``application/x-ndjson`` streaming responses,
+skipping empty lines and comment/meta lines (those starting with ``:``) .
+
+Used by endpoints that stream bare JSON objects with no ``data:`` prefix
+(e.g. ``/mcp/chat/stream``, ``/mcp/chat/stream/group_converse``).
+Callers are responsible for JSON-decoding the yielded strings.
+"""
+
+from __future__ import annotations
+
+from typing import AsyncGenerator, Generator
+
+import httpx
+
+
+def iter_ndjson_lines(response: httpx.Response) -> Generator[str, None, None]:
+    """Yield raw JSON lines from a *synchronous* streaming NDJSON response."""
+    buf = ""
+    for raw in response.iter_text():
+        buf += raw
+        while "\n" in buf:
+            line, buf = buf.split("\n", 1)
+            line = line.strip()
+            if not line or line.startswith(":"):
+                continue
+            yield line
+    if buf.strip():
+        line = buf.strip()
+        if not line.startswith(":"):
+            yield line
+
+
+async def aiter_ndjson_lines(response: httpx.Response) -> AsyncGenerator[str, None]:
+    """Yield raw JSON lines from an *async* streaming NDJSON response."""
+    buf = ""
+    async for raw in response.aiter_text():
+        buf += raw
+        while "\n" in buf:
+            line, buf = buf.split("\n", 1)
+            line = line.strip()
+            if not line or line.startswith(":"):
+                continue
+            yield line
+    if buf.strip():
+        line = buf.strip()
+        if not line.startswith(":"):
+            yield line

--- a/superme_sdk/_transport/_sse.py
+++ b/superme_sdk/_transport/_sse.py
@@ -1,10 +1,9 @@
-"""Shared SSE / NDJSON line-parsing utilities.
+"""SSE (Server-Sent Events) line-parsing utilities.
 
-Both sync and async variants yield the raw content for each event line.
-For SSE streams the ``data:`` prefix is stripped; bare JSON lines (NDJSON,
-i.e. lines starting with ``{``) are yielded as-is.  Empty lines and SSE
-comment/meta lines (``:``, ``event:``, ``id:``, ``retry:``) are skipped.
+Yields the raw ``data:`` payload for each SSE event line, stripping the
+``data:`` prefix and skipping empty lines and comment/meta lines.
 
+Used by endpoints that respond with ``text/event-stream`` (e.g. interview).
 Callers are responsible for JSON-decoding the yielded strings.
 """
 
@@ -15,52 +14,45 @@ from typing import AsyncGenerator, Generator
 import httpx
 
 
-def _yield_line(line: str) -> str | None:
-    """Return the payload to yield for a single SSE/NDJSON line, or None to skip."""
-    if not line or line.startswith(":"):
-        return None
-    if line.startswith("data: "):
-        return line[6:]
-    if line.startswith("data:"):
-        return line[5:]
-    if line.startswith("{"):
-        return line  # bare NDJSON object
-    return None
-
-
 def iter_sse_lines(response: httpx.Response) -> Generator[str, None, None]:
-    """Yield event payloads from a *synchronous* streaming httpx response.
-
-    Handles both SSE (``data: {json}\\n\\n``) and NDJSON (``{json}\\n``) formats.
-    """
+    """Yield SSE data payloads from a *synchronous* streaming httpx response."""
     buf = ""
     for raw in response.iter_text():
         buf += raw
         while "\n" in buf:
             line, buf = buf.split("\n", 1)
-            payload = _yield_line(line.strip())
-            if payload is not None:
-                yield payload
+            line = line.strip()
+            if not line or line.startswith(":"):
+                continue
+            if line.startswith("data: "):
+                yield line[6:]
+            elif line.startswith("data:"):
+                yield line[5:]
     if buf.strip():
-        payload = _yield_line(buf.strip())
-        if payload is not None:
-            yield payload
+        line = buf.strip()
+        if line.startswith("data: "):
+            yield line[6:]
+        elif line.startswith("data:"):
+            yield line[5:]
 
 
 async def aiter_sse_lines(response: httpx.Response) -> AsyncGenerator[str, None]:
-    """Yield event payloads from an *async* streaming httpx response.
-
-    Mirrors :func:`iter_sse_lines` but uses ``aiter_text()`` for async iteration.
-    """
+    """Yield SSE data payloads from an *async* streaming httpx response."""
     buf = ""
     async for raw in response.aiter_text():
         buf += raw
         while "\n" in buf:
             line, buf = buf.split("\n", 1)
-            payload = _yield_line(line.strip())
-            if payload is not None:
-                yield payload
+            line = line.strip()
+            if not line or line.startswith(":"):
+                continue
+            if line.startswith("data: "):
+                yield line[6:]
+            elif line.startswith("data:"):
+                yield line[5:]
     if buf.strip():
-        payload = _yield_line(buf.strip())
-        if payload is not None:
-            yield payload
+        line = buf.strip()
+        if line.startswith("data: "):
+            yield line[6:]
+        elif line.startswith("data:"):
+            yield line[5:]

--- a/superme_sdk/_transport/_sse.py
+++ b/superme_sdk/_transport/_sse.py
@@ -1,7 +1,9 @@
-"""Shared SSE (Server-Sent Events) line-parsing utilities.
+"""Shared SSE / NDJSON line-parsing utilities.
 
-Both sync and async variants yield the raw ``data:`` content for each SSE line,
-with the ``data:`` prefix stripped and empty / comment lines skipped.
+Both sync and async variants yield the raw content for each event line.
+For SSE streams the ``data:`` prefix is stripped; bare JSON lines (NDJSON,
+i.e. lines starting with ``{``) are yielded as-is.  Empty lines and SSE
+comment/meta lines (``:``, ``event:``, ``id:``, ``retry:``) are skipped.
 
 Callers are responsible for JSON-decoding the yielded strings.
 """
@@ -13,35 +15,40 @@ from typing import AsyncGenerator, Generator
 import httpx
 
 
-def iter_sse_lines(response: httpx.Response) -> Generator[str, None, None]:
-    """Yield SSE data lines from a *synchronous* streaming httpx response.
+def _yield_line(line: str) -> str | None:
+    """Return the payload to yield for a single SSE/NDJSON line, or None to skip."""
+    if not line or line.startswith(":"):
+        return None
+    if line.startswith("data: "):
+        return line[6:]
+    if line.startswith("data:"):
+        return line[5:]
+    if line.startswith("{"):
+        return line  # bare NDJSON object
+    return None
 
-    Strips the ``data:`` prefix, skips empty lines and SSE comment lines
-    (those starting with ``:``) and handles buffered partial lines.
+
+def iter_sse_lines(response: httpx.Response) -> Generator[str, None, None]:
+    """Yield event payloads from a *synchronous* streaming httpx response.
+
+    Handles both SSE (``data: {json}\\n\\n``) and NDJSON (``{json}\\n``) formats.
     """
     buf = ""
     for raw in response.iter_text():
         buf += raw
         while "\n" in buf:
             line, buf = buf.split("\n", 1)
-            line = line.strip()
-            if not line or line.startswith(":"):
-                continue
-            if line.startswith("data: "):
-                yield line[6:]
-            elif line.startswith("data:"):
-                yield line[5:]
-    # Flush any remaining data not terminated by a newline
+            payload = _yield_line(line.strip())
+            if payload is not None:
+                yield payload
     if buf.strip():
-        line = buf.strip()
-        if line.startswith("data: "):
-            yield line[6:]
-        elif line.startswith("data:"):
-            yield line[5:]
+        payload = _yield_line(buf.strip())
+        if payload is not None:
+            yield payload
 
 
 async def aiter_sse_lines(response: httpx.Response) -> AsyncGenerator[str, None]:
-    """Yield SSE data lines from an *async* streaming httpx response.
+    """Yield event payloads from an *async* streaming httpx response.
 
     Mirrors :func:`iter_sse_lines` but uses ``aiter_text()`` for async iteration.
     """
@@ -50,17 +57,10 @@ async def aiter_sse_lines(response: httpx.Response) -> AsyncGenerator[str, None]
         buf += raw
         while "\n" in buf:
             line, buf = buf.split("\n", 1)
-            line = line.strip()
-            if not line or line.startswith(":"):
-                continue
-            if line.startswith("data: "):
-                yield line[6:]
-            elif line.startswith("data:"):
-                yield line[5:]
-    # Flush any remaining data not terminated by a newline
+            payload = _yield_line(line.strip())
+            if payload is not None:
+                yield payload
     if buf.strip():
-        line = buf.strip()
-        if line.startswith("data: "):
-            yield line[6:]
-        elif line.startswith("data:"):
-            yield line[5:]
+        payload = _yield_line(buf.strip())
+        if payload is not None:
+            yield payload

--- a/superme_sdk/services/_conversations.py
+++ b/superme_sdk/services/_conversations.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import json
 import warnings
 from typing import Any, Generator, Optional
 

--- a/superme_sdk/services/_groups.py
+++ b/superme_sdk/services/_groups.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 from typing import Any, Optional
 
-from .._transport._sse import iter_sse_lines
+from .._transport._ndjson import iter_ndjson_lines
 
 
 class GroupsMixin:
@@ -92,7 +92,7 @@ class GroupsMixin:
             if not resp.is_success:
                 resp.read()
             self._check_rest_response(resp)
-            for line in iter_sse_lines(resp):
+            for line in iter_ndjson_lines(resp):
                 try:
                     obj = json.loads(line)
                 except (json.JSONDecodeError, ValueError):

--- a/superme_sdk/services/aio/_conversations.py
+++ b/superme_sdk/services/aio/_conversations.py
@@ -6,7 +6,7 @@ import json
 from typing import Any, AsyncGenerator, Optional
 
 from superme_sdk.models import StreamEvent
-from ..._transport._sse import aiter_sse_lines
+from ..._transport._ndjson import aiter_ndjson_lines
 
 
 class AsyncConversationsMixin:
@@ -54,7 +54,7 @@ class AsyncConversationsMixin:
                 await resp.aread()
             self._check_rest_response(resp)
 
-            async for line in aiter_sse_lines(resp):
+            async for line in aiter_ndjson_lines(resp):
                 try:
                     obj = json.loads(line)
                 except (json.JSONDecodeError, ValueError):

--- a/superme_sdk/services/aio/_groups.py
+++ b/superme_sdk/services/aio/_groups.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 from typing import Any, AsyncGenerator, Optional
 
-from ..._transport._sse import aiter_sse_lines
+from ..._transport._ndjson import aiter_ndjson_lines
 
 
 class AsyncGroupsMixin:
@@ -57,7 +57,7 @@ class AsyncGroupsMixin:
             if not resp.is_success:
                 await resp.aread()
             self._check_rest_response(resp)
-            async for line in aiter_sse_lines(resp):
+            async for line in aiter_ndjson_lines(resp):
                 try:
                     obj = json.loads(line)
                 except (json.JSONDecodeError, ValueError):

--- a/tests/test_async_client.py
+++ b/tests/test_async_client.py
@@ -20,8 +20,13 @@ REST_BASE = "https://www.superme.ai"
 
 
 def _sse(*objs) -> bytes:
-    """Encode dicts as ``data: <json>\\n\\n`` SSE lines."""
+    """Encode dicts as ``data: <json>\\n\\n`` SSE lines (interviews)."""
     return "".join(f"data: {json.dumps(o)}\n\n" for o in objs).encode()
+
+
+def _ndjson(*objs) -> bytes:
+    """Encode dicts as bare NDJSON lines (agent + group_converse endpoints)."""
+    return "".join(f"{json.dumps(o)}\n" for o in objs).encode()
 
 
 def _mcp_tool_response(result_dict: dict) -> dict:
@@ -61,13 +66,13 @@ async def test_async_client_context_manager():
 
 @respx.mock
 async def test_ask_my_agent_stream_yields_text_events():
-    sse = _sse(
+    ndjson = _ndjson(
         {"type": "content", "content": "Hello "},
         {"type": "content", "content": "world"},
         {"type": "done"},
     )
     respx.post(f"{MCP_BASE}/mcp/chat/stream").mock(
-        return_value=httpx.Response(200, content=sse)
+        return_value=httpx.Response(200, content=ndjson)
     )
     async with AsyncSuperMeClient(api_key="tok") as client:
         events = [ev async for ev in client.ask_my_agent_stream("hi")]
@@ -80,13 +85,13 @@ async def test_ask_my_agent_stream_yields_text_events():
 
 @respx.mock
 async def test_ask_my_agent_stream_final_event_has_done_true():
-    sse = _sse(
+    ndjson = _ndjson(
         {"type": "session_info", "metadata": {"session_id": "conv_xyz"}},
         {"type": "content", "content": "Hi"},
         {"type": "done"},
     )
     respx.post(f"{MCP_BASE}/mcp/chat/stream").mock(
-        return_value=httpx.Response(200, content=sse)
+        return_value=httpx.Response(200, content=ndjson)
     )
     async with AsyncSuperMeClient(api_key="tok") as client:
         events = [ev async for ev in client.ask_my_agent_stream("hi")]
@@ -96,13 +101,13 @@ async def test_ask_my_agent_stream_final_event_has_done_true():
 
 @respx.mock
 async def test_ask_my_agent_stream_propagates_conversation_id():
-    sse = _sse(
+    ndjson = _ndjson(
         {"type": "session_info", "metadata": {"session_id": "conv_abc"}},
         {"type": "content", "content": "Hi"},
         {"type": "done"},
     )
     respx.post(f"{MCP_BASE}/mcp/chat/stream").mock(
-        return_value=httpx.Response(200, content=sse)
+        return_value=httpx.Response(200, content=ndjson)
     )
     async with AsyncSuperMeClient(api_key="tok") as client:
         events = [ev async for ev in client.ask_my_agent_stream("hi")]
@@ -113,7 +118,7 @@ async def test_ask_my_agent_stream_propagates_conversation_id():
 @respx.mock
 async def test_ask_my_agent_stream_passes_conversation_id_in_payload():
     route = respx.post(f"{MCP_BASE}/mcp/chat/stream").mock(
-        return_value=httpx.Response(200, content=_sse({"type": "done"}))
+        return_value=httpx.Response(200, content=_ndjson({"type": "done"}))
     )
     async with AsyncSuperMeClient(api_key="tok") as client:
         async for _ in client.ask_my_agent_stream("hi", conversation_id="conv_existing"):
@@ -150,13 +155,13 @@ async def test_ask_my_agent_returns_dict():
 
 @respx.mock
 async def test_group_converse_stream_yields_perspectives():
-    sse = _sse(
+    ndjson = _ndjson(
         {"type": "perspective", "user_name": "Alice", "content": "My view..."},
         {"type": "perspective", "user_name": "Bob", "content": "I think..."},
         {"type": "done", "conversation_id": "gconv_1"},
     )
     respx.post(f"{MCP_BASE}/mcp/chat/stream/group_converse").mock(
-        return_value=httpx.Response(200, content=sse)
+        return_value=httpx.Response(200, content=ndjson)
     )
     async with AsyncSuperMeClient(api_key="tok") as client:
         events = [ev async for ev in client.group_converse_stream(["alice", "bob"], topic="AI future")]
@@ -169,12 +174,12 @@ async def test_group_converse_stream_yields_perspectives():
 
 @respx.mock
 async def test_group_converse_stream_final_event_has_done():
-    sse = _sse(
+    ndjson = _ndjson(
         {"type": "perspective", "user_name": "Alice", "content": "My view..."},
         {"type": "done", "conversation_id": "gconv_2"},
     )
     respx.post(f"{MCP_BASE}/mcp/chat/stream/group_converse").mock(
-        return_value=httpx.Response(200, content=sse)
+        return_value=httpx.Response(200, content=ndjson)
     )
     async with AsyncSuperMeClient(api_key="tok") as client:
         events = [ev async for ev in client.group_converse_stream(["alice", "bob"], topic="test")]
@@ -331,27 +336,3 @@ async def test_live_stream_interview_list(async_live_client):
     assert isinstance(interviews, list)
 
 
-def _ndjson(*objs) -> bytes:
-    """Encode dicts as bare NDJSON lines (no ``data:`` prefix)."""
-    return "".join(f"{json.dumps(o)}\n" for o in objs).encode()
-
-
-@respx.mock
-async def test_ask_my_agent_stream_ndjson_format():
-    """MCP /mcp/chat/stream sends NDJSON (no data: prefix) — must still work."""
-    ndjson = _ndjson(
-        {"type": "content", "content": "Hello "},
-        {"type": "content", "content": "world"},
-        {"type": "done"},
-    )
-    respx.post(f"{MCP_BASE}/mcp/chat/stream").mock(
-        return_value=httpx.Response(200, content=ndjson)
-    )
-    async with AsyncSuperMeClient(api_key="tok") as client:
-        events = [ev async for ev in client.ask_my_agent_stream("hi")]
-
-    text_events = [e for e in events if not e.done]
-    assert len(text_events) == 2
-    assert text_events[0].text == "Hello "
-    assert text_events[1].text == "world"
-    assert events[-1].done is True

--- a/tests/test_async_client.py
+++ b/tests/test_async_client.py
@@ -329,3 +329,29 @@ async def test_live_get_agentic_resume(async_live_client):
 async def test_live_stream_interview_list(async_live_client):
     interviews = await async_live_client.list_my_interviews()
     assert isinstance(interviews, list)
+
+
+def _ndjson(*objs) -> bytes:
+    """Encode dicts as bare NDJSON lines (no ``data:`` prefix)."""
+    return "".join(f"{json.dumps(o)}\n" for o in objs).encode()
+
+
+@respx.mock
+async def test_ask_my_agent_stream_ndjson_format():
+    """MCP /mcp/chat/stream sends NDJSON (no data: prefix) — must still work."""
+    ndjson = _ndjson(
+        {"type": "content", "content": "Hello "},
+        {"type": "content", "content": "world"},
+        {"type": "done"},
+    )
+    respx.post(f"{MCP_BASE}/mcp/chat/stream").mock(
+        return_value=httpx.Response(200, content=ndjson)
+    )
+    async with AsyncSuperMeClient(api_key="tok") as client:
+        events = [ev async for ev in client.ask_my_agent_stream("hi")]
+
+    text_events = [e for e in events if not e.done]
+    assert len(text_events) == 2
+    assert text_events[0].text == "Hello "
+    assert text_events[1].text == "world"
+    assert events[-1].done is True

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -460,3 +460,73 @@ class TestFindUsersOnTopic:
         result = client.find_users_on_topic("growth")
         assert result == FIND_USERS_RESULT
         client.close()
+
+
+# ---------------------------------------------------------------------------
+# Sync NDJSON streaming (ask_my_agent_stream, group_converse_stream)
+# ---------------------------------------------------------------------------
+
+
+def _ndjson(*objs) -> bytes:
+    """Encode dicts as bare NDJSON lines (no data: prefix) — what /mcp/chat/stream sends."""
+    return "".join(f"{json.dumps(o)}\n" for o in objs).encode()
+
+
+@respx.mock
+def test_sync_ask_my_agent_stream_yields_text_events():
+    ndjson = _ndjson(
+        {"type": "content", "content": "Hello "},
+        {"type": "content", "content": "world"},
+        {"type": "done"},
+    )
+    respx.post(f"{MCP_BASE}/mcp/chat/stream").mock(
+        return_value=httpx.Response(200, content=ndjson)
+    )
+    client = SuperMeClient(api_key="tok")
+    events = list(client.ask_my_agent_stream("hi"))
+    client.close()
+
+    text_events = [e for e in events if not e.done]
+    assert len(text_events) == 2
+    assert text_events[0].text == "Hello "
+    assert text_events[1].text == "world"
+    assert events[-1].done is True
+
+
+@respx.mock
+def test_sync_ask_my_agent_stream_propagates_conversation_id():
+    ndjson = _ndjson(
+        {"type": "session_info", "metadata": {"session_id": "conv_sync"}},
+        {"type": "content", "content": "Hi"},
+        {"type": "done"},
+    )
+    respx.post(f"{MCP_BASE}/mcp/chat/stream").mock(
+        return_value=httpx.Response(200, content=ndjson)
+    )
+    client = SuperMeClient(api_key="tok")
+    events = list(client.ask_my_agent_stream("hi"))
+    client.close()
+
+    assert events[-1].conversation_id == "conv_sync"
+
+
+@respx.mock
+def test_sync_group_converse_stream_yields_perspectives():
+    ndjson = _ndjson(
+        {"type": "perspective", "user_name": "Alice", "content": "My view..."},
+        {"type": "perspective", "user_name": "Bob", "content": "I think..."},
+        {"type": "done", "conversation_id": "gconv_s1"},
+    )
+    respx.post(f"{MCP_BASE}/mcp/chat/stream/group_converse").mock(
+        return_value=httpx.Response(200, content=ndjson)
+    )
+    client = SuperMeClient(api_key="tok")
+    events = list(client.group_converse_stream(["alice", "bob"], topic="test"))
+    client.close()
+
+    perspectives = [e for e in events if e.get("type") == "perspective"]
+    assert len(perspectives) == 2
+    assert perspectives[0]["user_name"] == "Alice"
+    done_event = events[-1]
+    assert done_event.get("_done") is True
+    assert done_event.get("conversation_id") == "gconv_s1"


### PR DESCRIPTION
## Summary

- Creates `superme_sdk/_transport/_ndjson.py` with `iter_ndjson_lines` / `aiter_ndjson_lines` — yields bare JSON lines, skips empty/comment lines
- Keeps `_sse.py` as pure SSE-only (data: prefix stripping) for interview endpoints
- Updates all NDJSON callers: `_http.py` (`_stream_direct`), `_conversations.py` async (`ask_my_agent_stream`), `_groups.py` sync+async (`group_converse_stream`)
- Updates tests: agent + group tests now mock NDJSON format; interview tests stay SSE

## Root cause

`/mcp/chat/stream` and `/mcp/chat/stream/group_converse` send `application/x-ndjson` — bare `{"type":"content",...}\n` lines with **no** `data:` prefix. `iter_sse_lines` only yielded lines starting with `data:`, so all agent/group events were silently dropped. The interview endpoint (`/api/v3/agent/interview/{id}/stream`) correctly sends `text/event-stream` and is unaffected.

## Test plan

- [x] `make test` — 131 tests pass
- [x] `make lint` — ruff clean

---
[duy 🐨 e8f: cli polishing](https://duy.superme.koala.army/task/019df138-f43d-7aa3-a9f4-f9c5521c4e8f)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added NDJSON streaming support for conversation and group responses.

* **Updates**
  * Streaming handlers now consume newline-delimited JSON for consistent stream parsing and event decoding.
  * SSE-related exports reduced; only transport essentials remain publicly exposed.

* **Chores**
  * Removed an unused import.

* **Tests**
  * Updated streaming tests and mocks to use NDJSON payloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace SSE parsing with NDJSON parsing for agent and group streaming endpoints
> - Adds a new [_ndjson.py](https://github.com/superme-ai/superme-sdk/pull/51/files#diff-fa553aead35981501f04dabaf1c287ed80fbc5fddd061786d4cc553f0cef1e31) module with sync (`iter_ndjson_lines`) and async (`aiter_ndjson_lines`) line parsers for bare NDJSON httpx responses.
> - Updates `HttpMixin._stream_direct`, `GroupsMixin.group_converse`, `AsyncConversationsMixin.ask_my_agent_stream`, and `AsyncGroupsMixin.group_converse_stream` to use NDJSON parsers instead of SSE parsers.
> - Removes `iter_sse_lines`/`aiter_sse_lines` from the `_transport` public API; SSE utilities remain in `_sse.py` but are no longer re-exported.
> - Behavioral Change: `/mcp/chat/stream` and `/mcp/chat/stream/group_converse` responses must now be bare NDJSON lines rather than SSE `data:` frames — any server still sending SSE format will break parsing.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f8b50b6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->