### PR TITLE
feat(library): add search_library method (v0.4.0)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "superme-sdk"
-version = "0.3.0"
+version = "0.4.0"
 description = "Python SDK for SuperMe AI API with OpenAI-compatible interface"
 readme = "README.md"
 authors = [

--- a/superme_sdk/services/_library.py
+++ b/superme_sdk/services/_library.py
@@ -128,6 +128,11 @@ class LibraryMixin:
             like ``InsightExcerpt`` (id, score, text, type, platform, url,
             chunk_index, date, ...).
         """
+        if not query or not query.strip():
+            raise ValueError("query must be a non-empty string")
+        if not 1 <= limit <= 50:
+            raise ValueError("limit must be between 1 and 50")
+
         uid = self.user_id
         if not uid:
             raise ValueError("Cannot extract user_id from token")

--- a/superme_sdk/services/_library.py
+++ b/superme_sdk/services/_library.py
@@ -93,6 +93,57 @@ class LibraryMixin:
         self._check_rest_response(resp)
         return resp.json()
 
+    def search_library(
+        self,
+        query: str,
+        *,
+        platform: Optional[str] = None,
+        limit: int = 20,
+    ) -> dict:
+        """Search the authenticated user's own library by free-text query.
+
+        Hybrid (semantic + lexical) search across notes, links, and social
+        posts. Includes drafts and private rows because the search is
+        self-scoped.
+
+        Example:
+            ```python
+            page = client.search_library("retrieval evaluation")
+            for hit in page["results"]:
+                print(hit["score"], hit["text"][:80])
+
+            # Filter to one platform
+            page = client.search_library("growth", platform="medium", limit=5)
+            ```
+
+        Args:
+            query: Free-text search query (required, non-empty).
+            platform: Optional platform filter (e.g. ``"medium"``, ``"x"``,
+                ``"linkedin"``, ``"github"``, ``"notion"``). ``None`` runs
+                across notes + links + social.
+            limit: Max excerpts to return (1-50, default 20).
+
+        Returns:
+            Dict with ``success`` and ``results`` — a list of excerpts shaped
+            like ``InsightExcerpt`` (id, score, text, type, platform, url,
+            chunk_index, date, ...).
+        """
+        uid = self.user_id
+        if not uid:
+            raise ValueError("Cannot extract user_id from token")
+
+        params: dict[str, Any] = {
+            "user_id": uid,
+            "query": query,
+            "limit": limit,
+        }
+        if platform is not None:
+            params["platform"] = platform
+
+        resp = self._rest_http.get("/api/v3/library/search", params=params)
+        self._check_rest_response(resp)
+        return resp.json()
+
     def get_ingestion_status(self) -> dict:
         """Check the ingestion status of the authenticated user's library.
 

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -275,6 +275,30 @@ class TestSearchLibrary:
             client.search_library("anything")
         client.close()
 
+    def test_raises_if_query_is_empty(self):
+        client = SuperMeClient(api_key=FAKE_JWT)
+        with pytest.raises(ValueError, match="non-empty"):
+            client.search_library("")
+        client.close()
+
+    def test_raises_if_query_is_whitespace(self):
+        client = SuperMeClient(api_key=FAKE_JWT)
+        with pytest.raises(ValueError, match="non-empty"):
+            client.search_library("   ")
+        client.close()
+
+    def test_raises_if_limit_too_low(self):
+        client = SuperMeClient(api_key=FAKE_JWT)
+        with pytest.raises(ValueError, match="1 and 50"):
+            client.search_library("pmf", limit=0)
+        client.close()
+
+    def test_raises_if_limit_too_high(self):
+        client = SuperMeClient(api_key=FAKE_JWT)
+        with pytest.raises(ValueError, match="1 and 50"):
+            client.search_library("pmf", limit=51)
+        client.close()
+
 
 # ---------------------------------------------------------------------------
 # Part B — Live e2e tests (require SUPERME_API_KEY, run with -m live)

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -28,7 +28,12 @@ FAKE_JWT = "eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoidWlkXzEyMyJ9.sig"
 
 class TestContractLibraryMethodsExist:
     def test_all_methods_present(self):
-        expected = ["get_learnings", "get_learning", "get_ingestion_status"]
+        expected = [
+            "get_learnings",
+            "get_learning",
+            "get_ingestion_status",
+            "search_library",
+        ]
         for name in expected:
             assert hasattr(SuperMeClient, name), f"SuperMeClient missing method: {name}"
             assert callable(getattr(SuperMeClient, name))
@@ -197,6 +202,80 @@ class TestGetIngestionStatus:
         client.close()
 
 
+class TestSearchLibrary:
+    @respx.mock
+    def test_calls_search_with_user_id_and_query(self):
+        route = respx.get(f"{REST_BASE}/api/v3/library/search").mock(
+            return_value=httpx.Response(200, json={"success": True, "results": []})
+        )
+        client = SuperMeClient(api_key=FAKE_JWT)
+        client.search_library("retrieval evaluation")
+        assert route.called
+        request_url = str(route.calls[0].request.url)
+        assert "user_id=uid_123" in request_url
+        assert "query=retrieval+evaluation" in request_url
+        assert "limit=20" in request_url
+        assert "platform=" not in request_url
+        client.close()
+
+    @respx.mock
+    def test_optional_platform_and_limit_forwarded(self):
+        route = respx.get(f"{REST_BASE}/api/v3/library/search").mock(
+            return_value=httpx.Response(200, json={"success": True, "results": []})
+        )
+        client = SuperMeClient(api_key=FAKE_JWT)
+        client.search_library("growth", platform="medium", limit=5)
+        request_url = str(route.calls[0].request.url)
+        assert "platform=medium" in request_url
+        assert "limit=5" in request_url
+        client.close()
+
+    @respx.mock
+    def test_returns_response(self):
+        payload = {
+            "success": True,
+            "results": [
+                {
+                    "id": "learning-1",
+                    "score": 0.91,
+                    "text": "PMF is when ...",
+                    "type": "input",
+                    "user_id": "uid_123",
+                }
+            ],
+        }
+        respx.get(f"{REST_BASE}/api/v3/library/search").mock(
+            return_value=httpx.Response(200, json=payload)
+        )
+        client = SuperMeClient(api_key=FAKE_JWT)
+        result = client.search_library("pmf")
+        assert result == payload
+        client.close()
+
+    @respx.mock
+    def test_4xx_raises(self):
+        respx.get(f"{REST_BASE}/api/v3/library/search").mock(
+            return_value=httpx.Response(403, json={"error": "forbidden"})
+        )
+        client = SuperMeClient(api_key=FAKE_JWT)
+        with pytest.raises(SuperMeError):
+            client.search_library("anything")
+        client.close()
+
+    def test_raises_if_no_user_id(self):
+        import base64
+        import json as _json
+
+        empty_payload = (
+            base64.urlsafe_b64encode(_json.dumps({}).encode()).rstrip(b"=").decode()
+        )
+        no_uid_jwt = f"eyJhbGciOiJIUzI1NiJ9.{empty_payload}.sig"
+        client = SuperMeClient(api_key=no_uid_jwt)
+        with pytest.raises(ValueError, match="user_id"):
+            client.search_library("anything")
+        client.close()
+
+
 # ---------------------------------------------------------------------------
 # Part B — Live e2e tests (require SUPERME_API_KEY, run with -m live)
 # ---------------------------------------------------------------------------
@@ -252,3 +331,11 @@ def test_live_get_learning_roundtrip(live_lib_client):
 def test_live_get_ingestion_status(live_lib_client):
     result = live_lib_client.get_ingestion_status()
     assert isinstance(result, dict)
+
+
+@pytest.mark.live
+def test_live_search_library_returns_results(live_lib_client):
+    result = live_lib_client.search_library("anything", limit=3)
+    assert isinstance(result, dict)
+    # Server may return empty results if the account has no library yet.
+    assert "results" in result or "success" in result

--- a/uv.lock
+++ b/uv.lock
@@ -600,7 +600,7 @@ wheels = [
 
 [[package]]
 name = "superme-sdk"
-version = "0.2.0"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary

Adds `client.search_library(query, *, platform=None, limit=20)` to `LibraryMixin`. Wraps the new backend route `GET /v3/library/search`. Same shape as `get_learnings`: routes through `_rest_http`, raises `ValueError` if the JWT has no `user_id`, surfaces backend HTTP errors via `_check_rest_response`.

Bumps version 0.3.0 → 0.4.0 (additive API; no breaking changes).

## Companion PRs
- Backend route + MCP tool: superme-ai/superme-backend#3591
- CLI consumer: superme-ai/superme-cli#TBD (depends on this being tagged as v0.4.0)

## Test plan
- [x] `tests/test_library.py::TestSearchLibrary` — 5 unit tests (mocked HTTP) cover happy path, optional platform/limit forwarding, response passthrough, 4xx, no-user_id ValueError.
- [x] Live `pytest -m live` test added (skip when `SUPERME_API_KEY` unset).
- [x] `make test` — 139 unit tests pass.
- [x] `make lint` — clean.

## Tagging
Tag this `v0.4.0` so the CLI PR can install via the existing git source pin.

---
[robin 🐨 2e1: library search: backend route + mcp tool + sdk method + cli command](https://robin.superme.koala.army/task/019df303-bbf2-7bb4-96f6-db1c70dd02e1)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added library search so users can query their own library with optional platform filtering and configurable result limits.

* **Tests**
  * Added unit and live tests covering search behavior, input validation, error handling, and result responses.

* **Chores**
  * Bumped package version to 0.4.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `search_library` method to `LibraryMixin` for GET /api/v3/library/search
> - Adds `LibraryMixin.search_library` in [`superme_sdk/services/_library.py`](https://github.com/superme-ai/superme-sdk/pull/52/files#diff-29a5439883c12232a99c56ad483e4289fe80ce9d4cda6df35492a8c48c273e60), which issues a GET to `/api/v3/library/search` with `user_id`, `query`, `limit` (default 20, range 1–50), and optional `platform`.
> - Raises `ValueError` for empty/whitespace queries, out-of-range limits, or a token missing `user_id`; raises `SuperMeError` on HTTP 4xx/5xx responses.
> - Adds full test coverage in [`tests/test_library.py`](https://github.com/superme-ai/superme-sdk/pull/52/files#diff-6632c1785126fef97a5f72f34de6c2d024be885e2096a16d37e5045d10cb1995) covering parameter forwarding, validation errors, HTTP errors, and a live integration test.
> - Bumps project version to 0.4.0.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fa29f0f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->