### PR TITLE
rename 'working group' to 'workgroup'

### DIFF
--- a/superme_sdk/client.py
+++ b/superme_sdk/client.py
@@ -18,12 +18,12 @@ from .services._interviews import InterviewsMixin
 from .services._library import LibraryMixin
 from .services._profiles import ProfilesMixin
 from .services._social import SocialMixin
-from .services._working_groups import WorkingGroupsMixin
+from .services._workgroups import WorkgroupsMixin
 from .services.aio._agentic_resume import AsyncAgenticResumeMixin
 from .services.aio._conversations import AsyncConversationsMixin
 from .services.aio._groups import AsyncGroupsMixin
 from .services.aio._interviews import AsyncInterviewsMixin
-from .services.aio._working_groups import AsyncWorkingGroupsMixin
+from .services.aio._workgroups import AsyncWorkgroupsMixin
 from .models import ChatCompletion, Choice, Message, Usage
 
 # Re-export for backward compatibility:
@@ -89,7 +89,7 @@ class SuperMeClient(
     LibraryMixin,
     ContentMixin,
     SocialMixin,
-    WorkingGroupsMixin,
+    WorkgroupsMixin,
     HttpMixin,
 ):
     """SuperMe API client with OpenAI-compatible interface.
@@ -186,7 +186,7 @@ class AsyncSuperMeClient(
     AsyncConversationsMixin,
     AsyncGroupsMixin,
     AsyncInterviewsMixin,
-    AsyncWorkingGroupsMixin,
+    AsyncWorkgroupsMixin,
     AsyncHttpMixin,
     # HttpMixin provides _check_rest_response, _parse_sse_json, _decode_jwt via MRO
     HttpMixin,

--- a/superme_sdk/services/_workgroups.py
+++ b/superme_sdk/services/_workgroups.py
@@ -1,6 +1,6 @@
-"""Working group methods — sync.
+"""Workgroup methods — sync.
 
-A *working group* is a saved set of SuperMe users (e.g. a project team or advisory
+A *workgroup* is a saved set of SuperMe users (e.g. a project team or advisory
 board) that the owner has assembled for repeated reference. Members are SuperMe
 users — resolve names via :meth:`find_user_by_name` first.
 """
@@ -10,46 +10,46 @@ from __future__ import annotations
 from typing import Any, Optional
 
 
-class WorkingGroupsMixin:
-    def list_working_groups(self) -> list[dict]:
-        """List your working groups, most recently used first.
+class WorkgroupsMixin:
+    def list_workgroups(self) -> list[dict]:
+        """List your workgroups, most recently used first.
 
         Example:
             ```python
-            for g in client.list_working_groups():
+            for g in client.list_workgroups():
                 print(g["handle"], g["name"], len(g["members"]))
             ```
 
         Returns:
-            List of working-group dicts. Each has ``id``, ``handle``, ``name``,
+            List of workgroup dicts. Each has ``id``, ``handle``, ``name``,
             ``description``, ``members`` (list of ``{user_id, name}``), and
             ``created_at`` / ``updated_at`` / ``last_used_at`` timestamps.
         """
-        result = self._mcp_tool_call("list_working_groups", {})
+        result = self._mcp_tool_call("list_workgroups", {})
         if isinstance(result, dict):
             groups = result.get("groups", [])
             return groups if isinstance(groups, list) else []
         return []
 
-    def get_working_group(self, group_id: str) -> Optional[dict]:
-        """Get a single working group by ID.
+    def get_workgroup(self, group_id: str) -> Optional[dict]:
+        """Get a single workgroup by ID.
 
         Example:
             ```python
-            group = client.get_working_group("abc123")
+            group = client.get_workgroup("abc123")
             for m in group["members"]:
                 print(m["user_id"], m["name"])
             ```
 
         Returns:
-            Working-group dict, or ``None`` if no group with that ID exists.
+            Workgroup dict, or ``None`` if no group with that ID exists.
         """
-        result = self._mcp_tool_call("get_working_group", {"group_id": group_id})
+        result = self._mcp_tool_call("get_workgroup", {"group_id": group_id})
         if isinstance(result, dict) and "error" not in result:
             return result
         return None
 
-    def create_working_group(
+    def create_workgroup(
         self,
         name: str,
         handle: str,
@@ -57,11 +57,11 @@ class WorkingGroupsMixin:
         description: str = "",
         members: Optional[list[dict]] = None,
     ) -> dict:
-        """Create a new working group.
+        """Create a new workgroup.
 
         Example:
             ```python
-            group = client.create_working_group(
+            group = client.create_workgroup(
                 name="Growth advisory board",
                 handle="growth-board",
                 members=[
@@ -80,7 +80,7 @@ class WorkingGroupsMixin:
                 Resolve names to user_ids via :meth:`find_user_by_name` first.
 
         Returns:
-            The created working-group dict (or ``{"error": ...}`` if the handle
+            The created workgroup dict (or ``{"error": ...}`` if the handle
             is already taken).
         """
         args: dict[str, Any] = {"name": name, "handle": handle}
@@ -88,9 +88,9 @@ class WorkingGroupsMixin:
             args["description"] = description
         if members is not None:
             args["members"] = members
-        return self._mcp_tool_call("create_working_group", args)
+        return self._mcp_tool_call("create_workgroup", args)
 
-    def update_working_group(
+    def update_workgroup(
         self,
         group_id: str,
         *,
@@ -99,14 +99,14 @@ class WorkingGroupsMixin:
         description: Optional[str] = None,
         members: Optional[list[dict]] = None,
     ) -> dict:
-        """Update an existing working group you own.
+        """Update an existing workgroup you own.
 
         Only the fields you pass are changed. ``members`` is a full replacement —
         pass the complete desired member list, not a delta.
 
         Example:
             ```python
-            client.update_working_group(
+            client.update_workgroup(
                 "abc123",
                 name="Growth advisors (Q2)",
                 members=[{"user_id": "abc", "name": "Casey"}],
@@ -114,7 +114,7 @@ class WorkingGroupsMixin:
             ```
 
         Returns:
-            The updated working-group dict, or ``{"error": ...}`` on conflict /
+            The updated workgroup dict, or ``{"error": ...}`` on conflict /
             not-found.
         """
         args: dict[str, Any] = {"group_id": group_id}
@@ -126,4 +126,4 @@ class WorkingGroupsMixin:
             args["description"] = description
         if members is not None:
             args["members"] = members
-        return self._mcp_tool_call("update_working_group", args)
+        return self._mcp_tool_call("update_workgroup", args)

--- a/superme_sdk/services/_workgroups.py
+++ b/superme_sdk/services/_workgroups.py
@@ -27,24 +27,24 @@ class WorkgroupsMixin:
         """
         result = self._mcp_tool_call("list_workgroups", {})
         if isinstance(result, dict):
-            groups = result.get("groups", [])
-            return groups if isinstance(groups, list) else []
+            workgroups = result.get("workgroups", [])
+            return workgroups if isinstance(workgroups, list) else []
         return []
 
-    def get_workgroup(self, group_id: str) -> Optional[dict]:
+    def get_workgroup(self, workgroup_id: str) -> Optional[dict]:
         """Get a single workgroup by ID.
 
         Example:
             ```python
-            group = client.get_workgroup("abc123")
-            for m in group["members"]:
+            workgroup = client.get_workgroup("abc123")
+            for m in workgroup["members"]:
                 print(m["user_id"], m["name"])
             ```
 
         Returns:
-            Workgroup dict, or ``None`` if no group with that ID exists.
+            Workgroup dict, or ``None`` if no workgroup with that ID exists.
         """
-        result = self._mcp_tool_call("get_workgroup", {"group_id": group_id})
+        result = self._mcp_tool_call("get_workgroup", {"workgroup_id": workgroup_id})
         if isinstance(result, dict) and "error" not in result:
             return result
         return None
@@ -61,7 +61,7 @@ class WorkgroupsMixin:
 
         Example:
             ```python
-            group = client.create_workgroup(
+            workgroup = client.create_workgroup(
                 name="Growth advisory board",
                 handle="growth-board",
                 members=[
@@ -69,7 +69,7 @@ class WorkgroupsMixin:
                     {"user_id": "def456", "name": "Elena Verna"},
                 ],
             )
-            print(group["id"])
+            print(workgroup["id"])
             ```
 
         Args:
@@ -92,7 +92,7 @@ class WorkgroupsMixin:
 
     def update_workgroup(
         self,
-        group_id: str,
+        workgroup_id: str,
         *,
         name: Optional[str] = None,
         handle: Optional[str] = None,
@@ -117,7 +117,7 @@ class WorkgroupsMixin:
             The updated workgroup dict, or ``{"error": ...}`` on conflict /
             not-found.
         """
-        args: dict[str, Any] = {"group_id": group_id}
+        args: dict[str, Any] = {"workgroup_id": workgroup_id}
         if name is not None:
             args["name"] = name
         if handle is not None:

--- a/superme_sdk/services/aio/__init__.py
+++ b/superme_sdk/services/aio/__init__.py
@@ -4,12 +4,12 @@ from ._agentic_resume import AsyncAgenticResumeMixin
 from ._conversations import AsyncConversationsMixin
 from ._groups import AsyncGroupsMixin
 from ._interviews import AsyncInterviewsMixin
-from ._working_groups import AsyncWorkingGroupsMixin
+from ._workgroups import AsyncWorkgroupsMixin
 
 __all__ = [
     "AsyncAgenticResumeMixin",
     "AsyncConversationsMixin",
     "AsyncGroupsMixin",
     "AsyncInterviewsMixin",
-    "AsyncWorkingGroupsMixin",
+    "AsyncWorkgroupsMixin",
 ]

--- a/superme_sdk/services/aio/_workgroups.py
+++ b/superme_sdk/services/aio/_workgroups.py
@@ -17,14 +17,14 @@ class AsyncWorkgroupsMixin:
         """List your workgroups, most recently used first (async)."""
         result = await self._async_mcp_tool_call("list_workgroups", {})
         if isinstance(result, dict):
-            groups = result.get("groups", [])
+            groups = result.get("workgroups", [])
             return groups if isinstance(groups, list) else []
         return []
 
-    async def get_workgroup(self, group_id: str) -> Optional[dict]:
+    async def get_workgroup(self, workgroup_id: str) -> Optional[dict]:
         """Get a single workgroup by ID (async)."""
         result = await self._async_mcp_tool_call(
-            "get_workgroup", {"group_id": group_id}
+            "get_workgroup", {"workgroup_id": workgroup_id}
         )
         if isinstance(result, dict) and "error" not in result:
             return result
@@ -48,7 +48,7 @@ class AsyncWorkgroupsMixin:
 
     async def update_workgroup(
         self,
-        group_id: str,
+        workgroup_id: str,
         *,
         name: Optional[str] = None,
         handle: Optional[str] = None,
@@ -59,7 +59,7 @@ class AsyncWorkgroupsMixin:
 
         ``members`` is a full replacement — pass the complete desired member list.
         """
-        args: dict[str, Any] = {"group_id": group_id}
+        args: dict[str, Any] = {"workgroup_id": workgroup_id}
         if name is not None:
             args["name"] = name
         if handle is not None:

--- a/superme_sdk/services/aio/_workgroups.py
+++ b/superme_sdk/services/aio/_workgroups.py
@@ -1,6 +1,6 @@
-"""Working group methods — async.
+"""Workgroup methods — async.
 
-A *working group* is a saved set of SuperMe users (e.g. a project team or advisory
+A *workgroup* is a saved set of SuperMe users (e.g. a project team or advisory
 board) that the owner has assembled for repeated reference. Members are SuperMe
 users — resolve names via :meth:`find_user_by_name` first.
 """
@@ -10,27 +10,27 @@ from __future__ import annotations
 from typing import Any, Optional
 
 
-class AsyncWorkingGroupsMixin:
-    """Async variants of :class:`~superme_sdk.services._working_groups.WorkingGroupsMixin`."""
+class AsyncWorkgroupsMixin:
+    """Async variants of :class:`~superme_sdk.services._workgroups.WorkgroupsMixin`."""
 
-    async def list_working_groups(self) -> list[dict]:
-        """List your working groups, most recently used first (async)."""
-        result = await self._async_mcp_tool_call("list_working_groups", {})
+    async def list_workgroups(self) -> list[dict]:
+        """List your workgroups, most recently used first (async)."""
+        result = await self._async_mcp_tool_call("list_workgroups", {})
         if isinstance(result, dict):
             groups = result.get("groups", [])
             return groups if isinstance(groups, list) else []
         return []
 
-    async def get_working_group(self, group_id: str) -> Optional[dict]:
-        """Get a single working group by ID (async)."""
+    async def get_workgroup(self, group_id: str) -> Optional[dict]:
+        """Get a single workgroup by ID (async)."""
         result = await self._async_mcp_tool_call(
-            "get_working_group", {"group_id": group_id}
+            "get_workgroup", {"group_id": group_id}
         )
         if isinstance(result, dict) and "error" not in result:
             return result
         return None
 
-    async def create_working_group(
+    async def create_workgroup(
         self,
         name: str,
         handle: str,
@@ -38,15 +38,15 @@ class AsyncWorkingGroupsMixin:
         description: str = "",
         members: Optional[list[dict]] = None,
     ) -> dict:
-        """Create a new working group (async)."""
+        """Create a new workgroup (async)."""
         args: dict[str, Any] = {"name": name, "handle": handle}
         if description:
             args["description"] = description
         if members is not None:
             args["members"] = members
-        return await self._async_mcp_tool_call("create_working_group", args)
+        return await self._async_mcp_tool_call("create_workgroup", args)
 
-    async def update_working_group(
+    async def update_workgroup(
         self,
         group_id: str,
         *,
@@ -55,7 +55,7 @@ class AsyncWorkingGroupsMixin:
         description: Optional[str] = None,
         members: Optional[list[dict]] = None,
     ) -> dict:
-        """Update an existing working group (async).
+        """Update an existing workgroup (async).
 
         ``members`` is a full replacement — pass the complete desired member list.
         """
@@ -68,4 +68,4 @@ class AsyncWorkingGroupsMixin:
             args["description"] = description
         if members is not None:
             args["members"] = members
-        return await self._async_mcp_tool_call("update_working_group", args)
+        return await self._async_mcp_tool_call("update_workgroup", args)

--- a/tests/test_workgroups.py
+++ b/tests/test_workgroups.py
@@ -37,7 +37,7 @@ def _mock_mcp(payload: dict):
 
 @respx.mock
 def test_list_workgroups_returns_list():
-    _mock_mcp({"groups": [GROUP], "count": 1})
+    _mock_mcp({"workgroups": [GROUP], "count": 1})
     client = SuperMeClient(api_key="tok")
     result = client.list_workgroups()
     assert result == [GROUP]
@@ -46,7 +46,7 @@ def test_list_workgroups_returns_list():
 
 @respx.mock
 def test_list_workgroups_empty():
-    _mock_mcp({"groups": [], "count": 0})
+    _mock_mcp({"workgroups": [], "count": 0})
     client = SuperMeClient(api_key="tok")
     assert client.list_workgroups() == []
     client.close()
@@ -96,7 +96,7 @@ def test_update_workgroup_only_passes_provided_fields():
     client.update_workgroup("wg_abc", name="renamed")
     body = json.loads(route.calls[0].request.content)
     args = body["params"]["arguments"]
-    assert args == {"group_id": "wg_abc", "name": "renamed"}
+    assert args == {"workgroup_id": "wg_abc", "name": "renamed"}
     client.close()
 
 
@@ -105,7 +105,7 @@ def test_update_workgroup_only_passes_provided_fields():
 async def test_async_list_workgroups():
     from superme_sdk.client import AsyncSuperMeClient
 
-    _mock_mcp({"groups": [GROUP], "count": 1})
+    _mock_mcp({"workgroups": [GROUP], "count": 1})
     async with AsyncSuperMeClient(api_key="tok") as client:
         result = await client.list_workgroups()
         assert result == [GROUP]

--- a/tests/test_workgroups.py
+++ b/tests/test_workgroups.py
@@ -1,4 +1,4 @@
-"""Tests for working-group SDK methods."""
+"""Tests for workgroup SDK methods."""
 
 import json
 
@@ -36,44 +36,44 @@ def _mock_mcp(payload: dict):
 
 
 @respx.mock
-def test_list_working_groups_returns_list():
+def test_list_workgroups_returns_list():
     _mock_mcp({"groups": [GROUP], "count": 1})
     client = SuperMeClient(api_key="tok")
-    result = client.list_working_groups()
+    result = client.list_workgroups()
     assert result == [GROUP]
     client.close()
 
 
 @respx.mock
-def test_list_working_groups_empty():
+def test_list_workgroups_empty():
     _mock_mcp({"groups": [], "count": 0})
     client = SuperMeClient(api_key="tok")
-    assert client.list_working_groups() == []
+    assert client.list_workgroups() == []
     client.close()
 
 
 @respx.mock
-def test_get_working_group_returns_dict():
+def test_get_workgroup_returns_dict():
     _mock_mcp(GROUP)
     client = SuperMeClient(api_key="tok")
-    result = client.get_working_group("wg_abc")
+    result = client.get_workgroup("wg_abc")
     assert result == GROUP
     client.close()
 
 
 @respx.mock
-def test_get_working_group_returns_none_on_error():
-    _mock_mcp({"error": "Working group not found: wg_missing"})
+def test_get_workgroup_returns_none_on_error():
+    _mock_mcp({"error": "Workgroup not found: wg_missing"})
     client = SuperMeClient(api_key="tok")
-    assert client.get_working_group("wg_missing") is None
+    assert client.get_workgroup("wg_missing") is None
     client.close()
 
 
 @respx.mock
-def test_create_working_group_returns_group():
+def test_create_workgroup_returns_group():
     route = _mock_mcp(GROUP)
     client = SuperMeClient(api_key="tok")
-    result = client.create_working_group(
+    result = client.create_workgroup(
         name="Growth advisory board",
         handle="growth-board",
         members=[{"user_id": "user_2", "name": "Casey"}],
@@ -81,7 +81,7 @@ def test_create_working_group_returns_group():
     assert result == GROUP
     # Verify the tool name + arguments
     body = json.loads(route.calls[0].request.content)
-    assert body["params"]["name"] == "create_working_group"
+    assert body["params"]["name"] == "create_workgroup"
     args = body["params"]["arguments"]
     assert args["name"] == "Growth advisory board"
     assert args["handle"] == "growth-board"
@@ -90,10 +90,10 @@ def test_create_working_group_returns_group():
 
 
 @respx.mock
-def test_update_working_group_only_passes_provided_fields():
+def test_update_workgroup_only_passes_provided_fields():
     route = _mock_mcp(GROUP)
     client = SuperMeClient(api_key="tok")
-    client.update_working_group("wg_abc", name="renamed")
+    client.update_workgroup("wg_abc", name="renamed")
     body = json.loads(route.calls[0].request.content)
     args = body["params"]["arguments"]
     assert args == {"group_id": "wg_abc", "name": "renamed"}
@@ -102,10 +102,10 @@ def test_update_working_group_only_passes_provided_fields():
 
 @pytest.mark.asyncio
 @respx.mock
-async def test_async_list_working_groups():
+async def test_async_list_workgroups():
     from superme_sdk.client import AsyncSuperMeClient
 
     _mock_mcp({"groups": [GROUP], "count": 1})
     async with AsyncSuperMeClient(api_key="tok") as client:
-        result = await client.list_working_groups()
+        result = await client.list_workgroups()
         assert result == [GROUP]

--- a/uv.lock
+++ b/uv.lock
@@ -600,7 +600,7 @@ wheels = [
 
 [[package]]
 name = "superme-sdk"
-version = "0.2.0"
+version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary
- Renames all "working group" / "working_group" references to "workgroup" / "workgroups" in sync and async SDK methods, client mixins, and tests
- File renames: `_working_groups.py` → `_workgroups.py` (sync + async), `test_working_groups.py` → `test_workgroups.py`
- Method names: `list_working_groups` → `list_workgroups`, `get_working_group` → `get_workgroup`, `create_working_group` → `create_workgroup`, `update_working_group` → `update_workgroup`

## Test plan
- [x] All 134 SDK tests pass
- [x] Coordinated with backend and CLI PRs



---
[robin 🐨 80b: workgroup](https://robin.superme.koala.army/task/019df3a5-bd59-7336-9844-5422f50e480b)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized workgroups API method names across the SDK for improved consistency (e.g., `list_working_groups()` → `list_workgroups()`).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Rename 'working group' to 'workgroup' across SDK mixins and MCP tool calls
> Renames all `WorkingGroupsMixin` classes, methods, and MCP tool names to use `workgroup` instead of `working_group`. The response key `groups` is also replaced with `workgroups` in list calls. Tests are updated to match the new naming.
>
> Risk: This is a breaking change for any callers using the old method names (e.g. `list_working_groups`) or parsing MCP tool responses with the `groups` key.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 544ea93.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->