### PR TITLE
revert: undo accidental direct push to main (search_library)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "superme-sdk"
-version = "0.4.0"
+version = "0.3.0"
 description = "Python SDK for SuperMe AI API with OpenAI-compatible interface"
 readme = "README.md"
 authors = [

--- a/superme_sdk/services/_library.py
+++ b/superme_sdk/services/_library.py
@@ -128,11 +128,6 @@ class LibraryMixin:
             like ``InsightExcerpt`` (id, score, text, type, platform, url,
             chunk_index, date, ...).
         """
-        if not query or not query.strip():
-            raise ValueError("query must be a non-empty string")
-        if not 1 <= limit <= 50:
-            raise ValueError("limit must be between 1 and 50")
-
         uid = self.user_id
         if not uid:
             raise ValueError("Cannot extract user_id from token")

--- a/superme_sdk/services/_library.py
+++ b/superme_sdk/services/_library.py
@@ -93,57 +93,6 @@ class LibraryMixin:
         self._check_rest_response(resp)
         return resp.json()
 
-    def search_library(
-        self,
-        query: str,
-        *,
-        platform: Optional[str] = None,
-        limit: int = 20,
-    ) -> dict:
-        """Search the authenticated user's own library by free-text query.
-
-        Hybrid (semantic + lexical) search across notes, links, and social
-        posts. Includes drafts and private rows because the search is
-        self-scoped.
-
-        Example:
-            ```python
-            page = client.search_library("retrieval evaluation")
-            for hit in page["results"]:
-                print(hit["score"], hit["text"][:80])
-
-            # Filter to one platform
-            page = client.search_library("growth", platform="medium", limit=5)
-            ```
-
-        Args:
-            query: Free-text search query (required, non-empty).
-            platform: Optional platform filter (e.g. ``"medium"``, ``"x"``,
-                ``"linkedin"``, ``"github"``, ``"notion"``). ``None`` runs
-                across notes + links + social.
-            limit: Max excerpts to return (1-50, default 20).
-
-        Returns:
-            Dict with ``success`` and ``results`` — a list of excerpts shaped
-            like ``InsightExcerpt`` (id, score, text, type, platform, url,
-            chunk_index, date, ...).
-        """
-        uid = self.user_id
-        if not uid:
-            raise ValueError("Cannot extract user_id from token")
-
-        params: dict[str, Any] = {
-            "user_id": uid,
-            "query": query,
-            "limit": limit,
-        }
-        if platform is not None:
-            params["platform"] = platform
-
-        resp = self._rest_http.get("/api/v3/library/search", params=params)
-        self._check_rest_response(resp)
-        return resp.json()
-
     def get_ingestion_status(self) -> dict:
         """Check the ingestion status of the authenticated user's library.
 

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -275,30 +275,6 @@ class TestSearchLibrary:
             client.search_library("anything")
         client.close()
 
-    def test_raises_if_query_is_empty(self):
-        client = SuperMeClient(api_key=FAKE_JWT)
-        with pytest.raises(ValueError, match="non-empty"):
-            client.search_library("")
-        client.close()
-
-    def test_raises_if_query_is_whitespace(self):
-        client = SuperMeClient(api_key=FAKE_JWT)
-        with pytest.raises(ValueError, match="non-empty"):
-            client.search_library("   ")
-        client.close()
-
-    def test_raises_if_limit_too_low(self):
-        client = SuperMeClient(api_key=FAKE_JWT)
-        with pytest.raises(ValueError, match="1 and 50"):
-            client.search_library("pmf", limit=0)
-        client.close()
-
-    def test_raises_if_limit_too_high(self):
-        client = SuperMeClient(api_key=FAKE_JWT)
-        with pytest.raises(ValueError, match="1 and 50"):
-            client.search_library("pmf", limit=51)
-        client.close()
-
 
 # ---------------------------------------------------------------------------
 # Part B — Live e2e tests (require SUPERME_API_KEY, run with -m live)

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -28,12 +28,7 @@ FAKE_JWT = "eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoidWlkXzEyMyJ9.sig"
 
 class TestContractLibraryMethodsExist:
     def test_all_methods_present(self):
-        expected = [
-            "get_learnings",
-            "get_learning",
-            "get_ingestion_status",
-            "search_library",
-        ]
+        expected = ["get_learnings", "get_learning", "get_ingestion_status"]
         for name in expected:
             assert hasattr(SuperMeClient, name), f"SuperMeClient missing method: {name}"
             assert callable(getattr(SuperMeClient, name))
@@ -202,80 +197,6 @@ class TestGetIngestionStatus:
         client.close()
 
 
-class TestSearchLibrary:
-    @respx.mock
-    def test_calls_search_with_user_id_and_query(self):
-        route = respx.get(f"{REST_BASE}/api/v3/library/search").mock(
-            return_value=httpx.Response(200, json={"success": True, "results": []})
-        )
-        client = SuperMeClient(api_key=FAKE_JWT)
-        client.search_library("retrieval evaluation")
-        assert route.called
-        request_url = str(route.calls[0].request.url)
-        assert "user_id=uid_123" in request_url
-        assert "query=retrieval+evaluation" in request_url
-        assert "limit=20" in request_url
-        assert "platform=" not in request_url
-        client.close()
-
-    @respx.mock
-    def test_optional_platform_and_limit_forwarded(self):
-        route = respx.get(f"{REST_BASE}/api/v3/library/search").mock(
-            return_value=httpx.Response(200, json={"success": True, "results": []})
-        )
-        client = SuperMeClient(api_key=FAKE_JWT)
-        client.search_library("growth", platform="medium", limit=5)
-        request_url = str(route.calls[0].request.url)
-        assert "platform=medium" in request_url
-        assert "limit=5" in request_url
-        client.close()
-
-    @respx.mock
-    def test_returns_response(self):
-        payload = {
-            "success": True,
-            "results": [
-                {
-                    "id": "learning-1",
-                    "score": 0.91,
-                    "text": "PMF is when ...",
-                    "type": "input",
-                    "user_id": "uid_123",
-                }
-            ],
-        }
-        respx.get(f"{REST_BASE}/api/v3/library/search").mock(
-            return_value=httpx.Response(200, json=payload)
-        )
-        client = SuperMeClient(api_key=FAKE_JWT)
-        result = client.search_library("pmf")
-        assert result == payload
-        client.close()
-
-    @respx.mock
-    def test_4xx_raises(self):
-        respx.get(f"{REST_BASE}/api/v3/library/search").mock(
-            return_value=httpx.Response(403, json={"error": "forbidden"})
-        )
-        client = SuperMeClient(api_key=FAKE_JWT)
-        with pytest.raises(SuperMeError):
-            client.search_library("anything")
-        client.close()
-
-    def test_raises_if_no_user_id(self):
-        import base64
-        import json as _json
-
-        empty_payload = (
-            base64.urlsafe_b64encode(_json.dumps({}).encode()).rstrip(b"=").decode()
-        )
-        no_uid_jwt = f"eyJhbGciOiJIUzI1NiJ9.{empty_payload}.sig"
-        client = SuperMeClient(api_key=no_uid_jwt)
-        with pytest.raises(ValueError, match="user_id"):
-            client.search_library("anything")
-        client.close()
-
-
 # ---------------------------------------------------------------------------
 # Part B — Live e2e tests (require SUPERME_API_KEY, run with -m live)
 # ---------------------------------------------------------------------------
@@ -331,11 +252,3 @@ def test_live_get_learning_roundtrip(live_lib_client):
 def test_live_get_ingestion_status(live_lib_client):
     result = live_lib_client.get_ingestion_status()
     assert isinstance(result, dict)
-
-
-@pytest.mark.live
-def test_live_search_library_returns_results(live_lib_client):
-    result = live_lib_client.search_library("anything", limit=3)
-    assert isinstance(result, dict)
-    # Server may return empty results if the account has no library yet.
-    assert "results" in result or "success" in result

--- a/uv.lock
+++ b/uv.lock
@@ -600,7 +600,7 @@ wheels = [
 
 [[package]]
 name = "superme-sdk"
-version = "0.4.0"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
Reverts fa29f0f and 7a1b582 which were accidentally pushed directly to main, bypassing the PR process.

These changes will be reintroduced properly through a new PR that also includes the 404-handling fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Project version downgraded to 0.3.0

* **Breaking Changes**
  * Removed library search functionality from the SDK

* **Tests**
  * Updated test suite to reflect API changes, removing search-related tests and adding new ingestion status validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Revert accidental addition of `search_library` to `LibraryMixin`
> - Removes the `search_library` method from [`LibraryMixin`](https://github.com/superme-ai/superme-sdk/pull/54/files#diff-29a5439883c12232a99c56ad483e4289fe80ce9d4cda6df35492a8c48c273e60) that was pushed directly to main, reverting to the previous state where the method did not exist.
> - Downgrades the package version in [`pyproject.toml`](https://github.com/superme-ai/superme-sdk/pull/54/files#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711) from `0.4.0` back to `0.3.0`.
> - Removes all related tests for `search_library` from [`tests/test_library.py`](https://github.com/superme-ai/superme-sdk/pull/54/files#diff-6632c1785126fef97a5f72f34de6c2d024be885e2096a16d37e5045d10cb1995), including contract, parameter validation, and live tests.
> - Risk: any code calling `client.search_library(...)` will now raise an `AttributeError` at runtime.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5b4cbd0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->