### PR TITLE
feat(library): add search_library method (v0.4.0)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "superme-sdk"
-version = "0.3.0"
+version = "0.4.0"
 description = "Python SDK for SuperMe AI API with OpenAI-compatible interface"
 readme = "README.md"
 authors = [

--- a/superme_sdk/services/_library.py
+++ b/superme_sdk/services/_library.py
@@ -93,6 +93,64 @@ class LibraryMixin:
         self._check_rest_response(resp)
         return resp.json()
 
+    def search_library(
+        self,
+        query: str,
+        *,
+        platform: Optional[str] = None,
+        limit: int = 20,
+    ) -> dict:
+        """Search the authenticated user's own library by free-text query.
+
+        Hybrid (semantic + lexical) search across notes, links, and social
+        posts. Includes drafts and private rows because the search is
+        self-scoped.
+
+        Example:
+            ```python
+            page = client.search_library("retrieval evaluation")
+            for hit in page["results"]:
+                print(hit["score"], hit["text"][:80])
+
+            # Filter to one platform
+            page = client.search_library("growth", platform="medium", limit=5)
+            ```
+
+        Args:
+            query: Free-text search query (required, non-empty).
+            platform: Optional platform filter (e.g. ``"medium"``, ``"x"``,
+                ``"linkedin"``, ``"github"``, ``"notion"``). ``None`` runs
+                across notes + links + social.
+            limit: Max excerpts to return (1-50, default 20).
+
+        Returns:
+            Dict with ``success`` and ``results`` — a list of excerpts shaped
+            like ``InsightExcerpt`` (id, score, text, type, platform, url,
+            chunk_index, date, ...).
+        """
+        if not query or not query.strip():
+            raise ValueError("query must be a non-empty string")
+        if not 1 <= limit <= 50:
+            raise ValueError("limit must be between 1 and 50")
+
+        uid = self.user_id
+        if not uid:
+            raise ValueError("Cannot extract user_id from token")
+
+        params: dict[str, Any] = {
+            "user_id": uid,
+            "query": query,
+            "limit": limit,
+        }
+        if platform is not None:
+            params["platform"] = platform
+
+        resp = self._rest_http.get("/api/v3/library/search", params=params)
+        if resp.status_code == 404:
+            return {"success": True, "results": []}
+        self._check_rest_response(resp)
+        return resp.json()
+
     def get_ingestion_status(self) -> dict:
         """Check the ingestion status of the authenticated user's library.
 

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -28,7 +28,7 @@ FAKE_JWT = "eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoidWlkXzEyMyJ9.sig"
 
 class TestContractLibraryMethodsExist:
     def test_all_methods_present(self):
-        expected = ["get_learnings", "get_learning", "get_ingestion_status"]
+        expected = ["get_learnings", "get_learning", "get_ingestion_status", "search_library"]
         for name in expected:
             assert hasattr(SuperMeClient, name), f"SuperMeClient missing method: {name}"
             assert callable(getattr(SuperMeClient, name))
@@ -197,6 +197,102 @@ class TestGetIngestionStatus:
         client.close()
 
 
+class TestSearchLibrary:
+    @respx.mock
+    def test_calls_search_with_user_id_and_query(self):
+        route = respx.get(f"{REST_BASE}/api/v3/library/search").mock(
+            return_value=httpx.Response(200, json={"success": True, "results": []})
+        )
+        client = SuperMeClient(api_key=FAKE_JWT)
+        client.search_library("retrieval evaluation")
+        assert route.called
+        url = str(route.calls[0].request.url)
+        assert "user_id=uid_123" in url
+        assert "query=retrieval+evaluation" in url
+        assert "limit=20" in url
+        assert "platform=" not in url
+        client.close()
+
+    @respx.mock
+    def test_optional_platform_and_limit_forwarded(self):
+        respx.get(f"{REST_BASE}/api/v3/library/search").mock(
+            return_value=httpx.Response(200, json={"success": True, "results": []})
+        )
+        client = SuperMeClient(api_key=FAKE_JWT)
+        client.search_library("growth", platform="medium", limit=5)
+        url = str(respx.calls[0].request.url)
+        assert "platform=medium" in url
+        assert "limit=5" in url
+        client.close()
+
+    @respx.mock
+    def test_returns_response(self):
+        payload = {"success": True, "results": [{"id": "r1", "score": 0.9, "text": "hi"}]}
+        respx.get(f"{REST_BASE}/api/v3/library/search").mock(
+            return_value=httpx.Response(200, json=payload)
+        )
+        client = SuperMeClient(api_key=FAKE_JWT)
+        result = client.search_library("hi")
+        assert result == payload
+        client.close()
+
+    @respx.mock
+    def test_404_returns_empty_results(self):
+        respx.get(f"{REST_BASE}/api/v3/library/search").mock(
+            return_value=httpx.Response(404, json={"success": False, "message": "Learning not found"})
+        )
+        client = SuperMeClient(api_key=FAKE_JWT)
+        result = client.search_library("nothing")
+        assert result == {"success": True, "results": []}
+        client.close()
+
+    @respx.mock
+    def test_other_4xx_raises(self):
+        respx.get(f"{REST_BASE}/api/v3/library/search").mock(
+            return_value=httpx.Response(400, json={"message": "bad request"})
+        )
+        client = SuperMeClient(api_key=FAKE_JWT)
+        with pytest.raises(SuperMeError):
+            client.search_library("query")
+        client.close()
+
+    def test_raises_if_query_is_empty(self):
+        client = SuperMeClient(api_key=FAKE_JWT)
+        with pytest.raises(ValueError, match="non-empty"):
+            client.search_library("")
+        client.close()
+
+    def test_raises_if_query_is_whitespace(self):
+        client = SuperMeClient(api_key=FAKE_JWT)
+        with pytest.raises(ValueError, match="non-empty"):
+            client.search_library("   ")
+        client.close()
+
+    def test_raises_if_limit_too_low(self):
+        client = SuperMeClient(api_key=FAKE_JWT)
+        with pytest.raises(ValueError, match="1 and 50"):
+            client.search_library("pmf", limit=0)
+        client.close()
+
+    def test_raises_if_limit_too_high(self):
+        client = SuperMeClient(api_key=FAKE_JWT)
+        with pytest.raises(ValueError, match="1 and 50"):
+            client.search_library("pmf", limit=51)
+        client.close()
+
+    def test_raises_if_no_user_id(self):
+        import base64
+        import json as _json
+        empty_payload = (
+            base64.urlsafe_b64encode(_json.dumps({}).encode()).rstrip(b"=").decode()
+        )
+        no_uid_jwt = f"eyJhbGciOiJIUzI1NiJ9.{empty_payload}.sig"
+        client = SuperMeClient(api_key=no_uid_jwt)
+        with pytest.raises(ValueError, match="user_id"):
+            client.search_library("anything")
+        client.close()
+
+
 # ---------------------------------------------------------------------------
 # Part B — Live e2e tests (require SUPERME_API_KEY, run with -m live)
 # ---------------------------------------------------------------------------
@@ -252,3 +348,29 @@ def test_live_get_learning_roundtrip(live_lib_client):
 def test_live_get_ingestion_status(live_lib_client):
     result = live_lib_client.get_ingestion_status()
     assert isinstance(result, dict)
+
+
+@pytest.mark.live
+def test_live_search_library_empty_or_results(live_lib_client):
+    """search_library returns a dict with a results list (may be empty)."""
+    result = live_lib_client.search_library("anything", limit=3)
+    assert isinstance(result, dict)
+    assert "results" in result
+
+
+@pytest.mark.live
+def test_live_search_library_with_results(live_lib_client):
+    """When search returns results, verify each hit has the expected shape."""
+    # Try a few generic terms — skip if the index hasn't caught up yet.
+    candidates = ["the", "a", "is", "and", "for", "in", "of"]
+    result = None
+    for q in candidates:
+        r = live_lib_client.search_library(q, limit=5)
+        if r.get("results"):
+            result = r
+            break
+    if result is None:
+        pytest.skip("Search index returned no results for any candidate query — index may not be ready")
+    assert "results" in result
+    hit = result["results"][0]
+    assert "id" in hit or "score" in hit or "text" in hit, f"unexpected hit shape: {hit}"


### PR DESCRIPTION
## Summary

- Adds `SuperMeClient.search_library(query, *, platform, limit)` — hits `GET /api/v3/library/search`
- Validates `query` non-empty and `limit` 1–50 client-side before the request
- Treats backend 404 (returned when no results exist) as an empty results list instead of raising `NotFoundError`
- Unit tests cover request construction, 404 handling, validation errors, and error propagation
- Live tests cover the empty-results case and result-shape verification when the index is ready

Depends on revert PR #54 merging first to clean up the accidental direct push.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `search_library` method to `LibraryMixin` for hybrid free-text library search
> - Adds `LibraryMixin.search_library(query, platform=None, limit=20)` in [`_library.py`](https://github.com/superme-ai/superme-sdk/pull/55/files#diff-29a5439883c12232a99c56ad483e4289fe80ce9d4cda6df35492a8c48c273e60), issuing a GET to `/api/v3/library/search` with `user_id` from the auth token.
> - Validates that `query` is non-empty, `limit` is within 1–50, and `user_id` is present; raises `ValueError` otherwise.
> - Returns `{"success": True, "results": []}` on HTTP 404; delegates other non-2xx errors to `_check_rest_response`.
> - Adds unit and live tests in [`tests/test_library.py`](https://github.com/superme-ai/superme-sdk/pull/55/files#diff-6632c1785126fef97a5f72f34de6c2d024be885e2096a16d37e5045d10cb1995) covering parameter forwarding, 404 handling, error cases, and result shape.
> - Bumps version to `0.4.0` in [`pyproject.toml`](https://github.com/superme-ai/superme-sdk/pull/55/files#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e01fb49.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added library search capability supporting free-text hybrid search across your personal library. Customize result limits (1–50) and filter by platform when needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->