### PR TITLE
add provisioning methods to SDK

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "superme-sdk"
-version = "0.5.0"
+version = "0.6.0"
 description = "Python SDK for SuperMe AI API with OpenAI-compatible interface"
 readme = "README.md"
 authors = [

--- a/superme_sdk/__init__.py
+++ b/superme_sdk/__init__.py
@@ -12,7 +12,7 @@ from .exceptions import (
 )
 from .models import StreamEvent, StageInfo, InterviewStatus
 
-__version__ = "0.1.0"
+__version__ = "0.6.0"
 __all__ = [
     "SuperMeClient",
     "AsyncSuperMeClient",

--- a/superme_sdk/client.py
+++ b/superme_sdk/client.py
@@ -16,12 +16,14 @@ from .services._groups import GroupsMixin
 from .services._interviews import InterviewsMixin
 from .services._library import LibraryMixin
 from .services._profiles import ProfilesMixin
+from .services._provision import ProvisionMixin
 from .services._social import SocialMixin
 from .services._workgroups import WorkgroupsMixin
 from .services.aio._agentic_resume import AsyncAgenticResumeMixin
 from .services.aio._conversations import AsyncConversationsMixin
 from .services.aio._groups import AsyncGroupsMixin
 from .services.aio._interviews import AsyncInterviewsMixin
+from .services.aio._provision import AsyncProvisionMixin
 from .services.aio._workgroups import AsyncWorkgroupsMixin
 from .models import ChatCompletion, Choice, Message, Usage
 
@@ -88,6 +90,7 @@ class SuperMeClient(
     ContentMixin,
     SocialMixin,
     WorkgroupsMixin,
+    ProvisionMixin,
     HttpMixin,
 ):
     """SuperMe API client with OpenAI-compatible interface.
@@ -185,6 +188,7 @@ class AsyncSuperMeClient(
     AsyncGroupsMixin,
     AsyncInterviewsMixin,
     AsyncWorkgroupsMixin,
+    AsyncProvisionMixin,
     AsyncHttpMixin,
     # HttpMixin provides _check_rest_response, _parse_sse_json, _decode_jwt via MRO
     HttpMixin,

--- a/superme_sdk/services/_provision.py
+++ b/superme_sdk/services/_provision.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-import asyncio
+import concurrent.futures
+import threading
 from typing import Any, Optional
 
 
@@ -112,25 +113,23 @@ class ProvisionMixin:
             List of result dicts in the same order as ``profiles``.
         """
 
-        async def _run() -> list[dict[str, Any]]:
-            sem = asyncio.Semaphore(_BATCH_CONCURRENCY)
+        sem = threading.Semaphore(_BATCH_CONCURRENCY)
+        results: list[dict[str, Any]] = [{}] * len(profiles)
 
-            async def _one(profile: dict[str, Any]) -> dict[str, Any]:
-                async with sem:
-                    return await asyncio.to_thread(
-                        self.provision_create, community_id, **profile
-                    )
-
-            tasks = [asyncio.create_task(_one(p)) for p in profiles]
-            results = []
-            for task in tasks:
+        def _one(index: int, profile: dict[str, Any]) -> None:
+            with sem:
                 try:
-                    results.append(await task)
+                    results[index] = self.provision_create(community_id, **profile)
                 except Exception as exc:  # noqa: BLE001
-                    results.append({"error": str(exc)})
-            return results
+                    results[index] = {"error": str(exc)}
 
-        return asyncio.run(_run())
+        with concurrent.futures.ThreadPoolExecutor(
+            max_workers=_BATCH_CONCURRENCY
+        ) as pool:
+            futs = [pool.submit(_one, i, p) for i, p in enumerate(profiles)]
+            concurrent.futures.wait(futs)
+
+        return results
 
     def provision_send_invites(
         self,

--- a/superme_sdk/services/_provision.py
+++ b/superme_sdk/services/_provision.py
@@ -1,0 +1,186 @@
+"""Provisioning methods — create and invite community members."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Optional
+
+
+_BATCH_CONCURRENCY = 10
+
+
+class ProvisionMixin:
+    def provision_create(
+        self,
+        community_id: str,
+        *,
+        name: str,
+        linkedin_url: str,
+        contact_email: Optional[str] = None,
+        notes: Optional[str] = None,
+        socials: Optional[dict[str, str]] = None,
+        external_urls: Optional[list[str]] = None,
+    ) -> dict[str, Any]:
+        """Provision a single community member.
+
+        Example:
+            ```python
+            result = client.provision_create(
+                "community_abc",
+                name="Jane Smith",
+                linkedin_url="https://linkedin.com/in/janesmith",
+                contact_email="jane@example.com",
+                notes="Met at Dubai summit",
+            )
+            print(result["provision"]["user_id"])
+            ```
+
+        Args:
+            community_id: The community to provision into.
+            name: Full name of the person being provisioned.
+            linkedin_url: LinkedIn profile URL (``linkedin.com/in/<slug>``).
+            contact_email: Email address for invite delivery.
+            notes: Community-scoped note (e.g. intro context, WhatsApp note).
+            socials: Platform handles, e.g. ``{"x": "janesmith"}``.
+            external_urls: URLs to import into the person's knowledge base.
+
+        Returns:
+            Dict with ``provision`` record including ``user_id``, ``token``,
+            ``claim_url``, and ``status``.
+        """
+        body: dict[str, Any] = {
+            "community_id": community_id,
+            "name": name,
+            "linkedin_url": linkedin_url,
+        }
+        if contact_email is not None:
+            body["contact_email"] = contact_email
+        if notes is not None:
+            body["notes"] = notes
+        if socials is not None:
+            body["socials"] = socials
+        if external_urls is not None:
+            body["external_urls"] = external_urls
+
+        resp = self._rest_http.post(f"/api/v3/provision/{community_id}", json=body)
+        self._check_rest_response(resp)
+        return resp.json()
+
+    def provision_create_batch(
+        self,
+        community_id: str,
+        profiles: list[dict[str, Any]],
+    ) -> list[dict[str, Any]]:
+        """Provision multiple community members concurrently.
+
+        Fans out up to 10 concurrent :meth:`provision_create` calls; caller
+        supplies a plain list of profile dicts. Results are returned in the
+        same order as ``profiles``. Failed items have an ``"error"`` key instead
+        of ``"provision"``.
+
+        Example:
+            ```python
+            results = client.provision_create_batch(
+                "community_abc",
+                profiles=[
+                    {
+                        "name": "Jane Smith",
+                        "linkedin_url": "https://linkedin.com/in/janesmith",
+                        "notes": "WhatsApp intro: loves B2B SaaS",
+                    },
+                    {
+                        "name": "John Doe",
+                        "linkedin_url": "https://linkedin.com/in/johndoe",
+                        "contact_email": "john@example.com",
+                    },
+                ],
+            )
+            for r in results:
+                if "error" in r:
+                    print("failed:", r["error"])
+                else:
+                    print("provisioned:", r["provision"]["user_id"])
+            ```
+
+        Args:
+            community_id: The community to provision into.
+            profiles: List of profile dicts. Each supports the same keys as
+                :meth:`provision_create` (``name``, ``linkedin_url``,
+                ``contact_email``, ``notes``, ``socials``, ``external_urls``).
+
+        Returns:
+            List of result dicts in the same order as ``profiles``.
+        """
+
+        async def _run() -> list[dict[str, Any]]:
+            sem = asyncio.Semaphore(_BATCH_CONCURRENCY)
+
+            async def _one(profile: dict[str, Any]) -> dict[str, Any]:
+                async with sem:
+                    return await asyncio.to_thread(
+                        self.provision_create, community_id, **profile
+                    )
+
+            tasks = [asyncio.create_task(_one(p)) for p in profiles]
+            results = []
+            for task in tasks:
+                try:
+                    results.append(await task)
+                except Exception as exc:  # noqa: BLE001
+                    results.append({"error": str(exc)})
+            return results
+
+        return asyncio.run(_run())
+
+    def provision_send_invites(
+        self,
+        community_id: str,
+        user_ids: list[str],
+    ) -> dict[str, Any]:
+        """Send invite emails to provisioned members.
+
+        Example:
+            ```python
+            result = client.provision_send_invites(
+                "community_abc",
+                user_ids=["user_123", "user_456"],
+            )
+            print(result["sent"], result["skipped"], result["failed"])
+            ```
+
+        Args:
+            community_id: The community whose provisions to invite.
+            user_ids: List of provisioned user IDs to send invites to.
+
+        Returns:
+            Dict with ``sent``, ``skipped``, and ``failed`` lists.
+        """
+        resp = self._rest_http.post(
+            f"/api/v3/provision/{community_id}/invite",
+            json={"community_id": community_id, "user_ids": user_ids},
+        )
+        self._check_rest_response(resp)
+        return resp.json()
+
+    def provision_list(self, community_id: str) -> dict[str, Any]:
+        """List all provisions for a community.
+
+        Example:
+            ```python
+            result = client.provision_list("community_abc")
+            for p in result["provisions"]:
+                print(p["user_id"], p["status"])
+            ```
+
+        Args:
+            community_id: The community to list provisions for.
+
+        Returns:
+            Dict with ``provisions`` list and ``count``.
+        """
+        resp = self._rest_http.get(
+            f"/api/v3/provision/{community_id}",
+            params={"community_id": community_id},
+        )
+        self._check_rest_response(resp)
+        return resp.json()

--- a/superme_sdk/services/_provision.py
+++ b/superme_sdk/services/_provision.py
@@ -3,11 +3,37 @@
 from __future__ import annotations
 
 import concurrent.futures
-import threading
 from typing import Any, Optional
+
+import httpx
 
 
 _BATCH_CONCURRENCY = 10
+
+
+def _provision_body(
+    community_id: str,
+    name: str,
+    linkedin_url: str,
+    contact_email: Optional[str] = None,
+    notes: Optional[str] = None,
+    socials: Optional[dict[str, str]] = None,
+    external_urls: Optional[list[str]] = None,
+) -> dict[str, Any]:
+    body: dict[str, Any] = {
+        "community_id": community_id,
+        "name": name,
+        "linkedin_url": linkedin_url,
+    }
+    if contact_email is not None:
+        body["contact_email"] = contact_email
+    if notes is not None:
+        body["notes"] = notes
+    if socials is not None:
+        body["socials"] = socials
+    if external_urls is not None:
+        body["external_urls"] = external_urls
+    return body
 
 
 class ProvisionMixin:
@@ -49,20 +75,15 @@ class ProvisionMixin:
             Dict with ``provision`` record including ``user_id``, ``token``,
             ``claim_url``, and ``status``.
         """
-        body: dict[str, Any] = {
-            "community_id": community_id,
-            "name": name,
-            "linkedin_url": linkedin_url,
-        }
-        if contact_email is not None:
-            body["contact_email"] = contact_email
-        if notes is not None:
-            body["notes"] = notes
-        if socials is not None:
-            body["socials"] = socials
-        if external_urls is not None:
-            body["external_urls"] = external_urls
-
+        body = _provision_body(
+            community_id,
+            name,
+            linkedin_url,
+            contact_email,
+            notes,
+            socials,
+            external_urls,
+        )
         resp = self._rest_http.post(f"/api/v3/provision/{community_id}", json=body)
         self._check_rest_response(resp)
         return resp.json()
@@ -74,10 +95,10 @@ class ProvisionMixin:
     ) -> list[dict[str, Any]]:
         """Provision multiple community members concurrently.
 
-        Fans out up to 10 concurrent :meth:`provision_create` calls; caller
-        supplies a plain list of profile dicts. Results are returned in the
-        same order as ``profiles``. Failed items have an ``"error"`` key instead
-        of ``"provision"``.
+        Fans out up to 10 concurrent requests using a dedicated batch-scoped
+        HTTP client (avoids sharing the main client across threads). Results
+        are returned in the same order as ``profiles``. Failed items have an
+        ``"error"`` key instead of ``"provision"``.
 
         Example:
             ```python
@@ -112,22 +133,36 @@ class ProvisionMixin:
         Returns:
             List of result dicts in the same order as ``profiles``.
         """
-
-        sem = threading.Semaphore(_BATCH_CONCURRENCY)
         results: list[dict[str, Any]] = [{}] * len(profiles)
 
-        def _one(index: int, profile: dict[str, Any]) -> None:
-            with sem:
-                try:
-                    results[index] = self.provision_create(community_id, **profile)
-                except Exception as exc:  # noqa: BLE001
-                    results[index] = {"error": str(exc)}
+        # Fresh client scoped to this batch — avoids sharing self._rest_http across threads.
+        batch_client = httpx.Client(
+            base_url=self.rest_base_url,
+            headers={
+                "Authorization": f"Bearer {self.api_key}",
+                "Content-Type": "application/json",
+                "Accept": "application/json, text/event-stream",
+            },
+            timeout=self._rest_http.timeout,
+        )
 
-        with concurrent.futures.ThreadPoolExecutor(
-            max_workers=_BATCH_CONCURRENCY
-        ) as pool:
-            futs = [pool.submit(_one, i, p) for i, p in enumerate(profiles)]
-            concurrent.futures.wait(futs)
+        def _one(index: int, profile: dict[str, Any]) -> None:
+            try:
+                body = _provision_body(community_id, **profile)
+                resp = batch_client.post(f"/api/v3/provision/{community_id}", json=body)
+                self._check_rest_response(resp)
+                results[index] = resp.json()
+            except Exception as exc:  # noqa: BLE001
+                results[index] = {"error": str(exc)}
+
+        try:
+            with concurrent.futures.ThreadPoolExecutor(
+                max_workers=_BATCH_CONCURRENCY
+            ) as pool:
+                futs = [pool.submit(_one, i, p) for i, p in enumerate(profiles)]
+                concurrent.futures.wait(futs)
+        finally:
+            batch_client.close()
 
         return results
 

--- a/superme_sdk/services/aio/_provision.py
+++ b/superme_sdk/services/aio/_provision.py
@@ -1,0 +1,128 @@
+"""Async provisioning methods."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Optional
+
+
+_BATCH_CONCURRENCY = 10
+
+
+class AsyncProvisionMixin:
+    async def provision_create(
+        self,
+        community_id: str,
+        *,
+        name: str,
+        linkedin_url: str,
+        contact_email: Optional[str] = None,
+        notes: Optional[str] = None,
+        socials: Optional[dict[str, str]] = None,
+        external_urls: Optional[list[str]] = None,
+    ) -> dict[str, Any]:
+        """Provision a single community member (async).
+
+        Args:
+            community_id: The community to provision into.
+            name: Full name of the person being provisioned.
+            linkedin_url: LinkedIn profile URL (``linkedin.com/in/<slug>``).
+            contact_email: Email address for invite delivery.
+            notes: Community-scoped note (e.g. intro context, WhatsApp note).
+            socials: Platform handles, e.g. ``{"x": "janesmith"}``.
+            external_urls: URLs to import into the person's knowledge base.
+
+        Returns:
+            Dict with ``provision`` record including ``user_id``, ``token``,
+            ``claim_url``, and ``status``.
+        """
+        body: dict[str, Any] = {
+            "community_id": community_id,
+            "name": name,
+            "linkedin_url": linkedin_url,
+        }
+        if contact_email is not None:
+            body["contact_email"] = contact_email
+        if notes is not None:
+            body["notes"] = notes
+        if socials is not None:
+            body["socials"] = socials
+        if external_urls is not None:
+            body["external_urls"] = external_urls
+
+        resp = await self._async_rest_http.post(
+            f"/api/v3/provision/{community_id}", json=body
+        )
+        self._check_rest_response(resp)
+        return resp.json()
+
+    async def provision_create_batch(
+        self,
+        community_id: str,
+        profiles: list[dict[str, Any]],
+    ) -> list[dict[str, Any]]:
+        """Provision multiple community members concurrently (async).
+
+        Fans out up to 10 concurrent :meth:`provision_create` calls.
+        Results are in the same order as ``profiles``; failed items have an
+        ``"error"`` key instead of ``"provision"``.
+
+        Args:
+            community_id: The community to provision into.
+            profiles: List of profile dicts (``name``, ``linkedin_url``,
+                ``contact_email``, ``notes``, ``socials``, ``external_urls``).
+
+        Returns:
+            List of result dicts in the same order as ``profiles``.
+        """
+        sem = asyncio.Semaphore(_BATCH_CONCURRENCY)
+
+        async def _one(profile: dict[str, Any]) -> dict[str, Any]:
+            async with sem:
+                return await self.provision_create(community_id, **profile)
+
+        tasks = [asyncio.create_task(_one(p)) for p in profiles]
+        results = []
+        for task in tasks:
+            try:
+                results.append(await task)
+            except Exception as exc:  # noqa: BLE001
+                results.append({"error": str(exc)})
+        return results
+
+    async def provision_send_invites(
+        self,
+        community_id: str,
+        user_ids: list[str],
+    ) -> dict[str, Any]:
+        """Send invite emails to provisioned members (async).
+
+        Args:
+            community_id: The community whose provisions to invite.
+            user_ids: List of provisioned user IDs to send invites to.
+
+        Returns:
+            Dict with ``sent``, ``skipped``, and ``failed`` lists.
+        """
+        resp = await self._async_rest_http.post(
+            f"/api/v3/provision/{community_id}/invite",
+            json={"community_id": community_id, "user_ids": user_ids},
+        )
+        self._check_rest_response(resp)
+        return resp.json()
+
+    async def provision_list(self, community_id: str) -> dict[str, Any]:
+        """List all provisions for a community (async).
+
+        Args:
+            community_id: The community to list provisions for.
+
+        Returns:
+            Dict with ``provisions`` list and ``count``.
+        """
+        resp = await self._async_rest_http.get(
+            f"/api/v3/provision/{community_id}",
+            params={"community_id": community_id},
+        )
+        self._check_rest_response(resp)
+        return resp.json()


### PR DESCRIPTION
## Summary
- Adds `provision_create()`, `provision_create_batch()`, `provision_send_invites()`, and `provision_list()` to `SuperMeClient` and `AsyncSuperMeClient`
- `provision_create_batch()` fans out concurrent single-provision calls (capped at 10 in-flight via semaphore) — caller gets user IDs back immediately for downstream linking
- Depends on backend PR: superme-ai/superme-backend#5350 (adds `notes` field)

## Usage
```python
# Single provision with community-scoped note
result = client.provision_create(
    "community_abc",
    name="Jane Smith",
    linkedin_url="https://linkedin.com/in/janesmith",
    contact_email="jane@example.com",
    notes="Met at Dubai summit, WhatsApp intro sent",
)
user_id = result["provision"]["user_id"]

# Batch provision
results = client.provision_create_batch(
    "community_abc",
    profiles=[
        {"name": "Jane", "linkedin_url": "...", "notes": "intro context"},
        {"name": "John", "linkedin_url": "...", "contact_email": "john@example.com"},
    ],
)
```

## Test plan
- [ ] `provision_create()` returns provision record with `user_id` and `claim_url`
- [ ] `provision_create_batch()` returns results in same order as input
- [ ] Failed items in batch have `"error"` key, don't abort the rest
- [ ] `provision_send_invites()` sends emails and returns sent/skipped/failed breakdown
- [ ] `AsyncSuperMeClient` variants work correctly in async context

---
[duy 🐨 7b9: Provisioning to sdk](https://duy.superme.koala.army/task/019ee34d-95b7-7885-a0a9-29a190e157b9)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add provisioning methods to the SuperMe SDK client
> - Adds `ProvisionMixin` and `AsyncProvisionMixin` to [`superme_sdk/services/_provision.py`](https://github.com/superme-ai/superme-sdk/pull/57/files#diff-b0846be0f0953b8159a8863fa816060b3e37d20a3b78a8576440118e28751f61) and [`superme_sdk/services/aio/_provision.py`](https://github.com/superme-ai/superme-sdk/pull/57/files#diff-db24617109c5bbe7f256926a387664b2b68b39f65b83d5bc41ea2e4f35ae2c09), exposing `provision_create`, `provision_create_batch`, `provision_send_invites`, and `provision_list` on both `SuperMeClient` and `AsyncSuperMeClient`.
> - `provision_create_batch` runs up to 10 concurrent requests using `ThreadPoolExecutor` (sync) or `asyncio.Semaphore` (async), preserving input order and recording per-item errors as `{'error': str(exc)}`.
> - Bumps the SDK version from `0.5.0` to `0.6.0`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1379260.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added provisioning workflows for community member onboarding (sync and async support).
  * Create individual member provisions with LinkedIn profile plus optional contact details, notes, socials, and external URLs.
  * Batch create provisions with bounded concurrency, preserving input order and returning per-item errors.
  * Send invite emails to provisioned members.
  * List existing provisions for a community.
* **Chores**
  * Bumped package version to 0.6.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->