### PR TITLE
docs(sdk): document provisioning methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,15 @@ make test-live
 | `get_interview_status(interview_id)` | `dict` | Poll interview status and stages. |
 | `get_interview_transcript(interview_id)` | `dict` | Get the full transcript for a completed interview. |
 
+#### Provisioning
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `provision_create(community_id, *, name, linkedin_url, contact_email, notes, socials, external_urls)` | `dict` | Provision a single community member. Returns a `provision` record with `user_id`, `token`, `claim_url`, and `status`. |
+| `provision_create_batch(community_id, profiles)` | `list[dict]` | Provision multiple members concurrently (up to 10 in flight). Results match the order of `profiles`; failed items have an `"error"` key instead of `"provision"`. |
+| `provision_send_invites(community_id, user_ids)` | `dict` | Send invite emails to provisioned members. Returns `sent`, `skipped`, and `failed` lists. |
+| `provision_list(community_id)` | `dict` | List all provisions for a community. Returns `provisions` and `count`. |
+
 #### OpenAI-compatible interface
 
 | Method | Returns | Description |

--- a/docs/api/services/aio/provision.md
+++ b/docs/api/services/aio/provision.md
@@ -1,0 +1,3 @@
+# Provisioning (async)
+
+::: superme_sdk.services.aio._provision.AsyncProvisionMixin

--- a/docs/api/services/provision.md
+++ b/docs/api/services/provision.md
@@ -1,0 +1,3 @@
+# Provisioning
+
+::: superme_sdk.services._provision.ProvisionMixin

--- a/docs/index.md
+++ b/docs/index.md
@@ -36,4 +36,4 @@ print(result["answer"])
 - [Models](api/models.md) — response data models (`StreamEvent`, `ChatCompletion`, …)
 - [Auth](api/auth.md) — token helpers
 - [Chat](api/chat.md) — OpenAI-compatible chat interface
-- **Services** — [Profiles](api/services/profiles.md), [Conversations](api/services/conversations.md), [Groups](api/services/groups.md), [Companies & Roles](api/services/companies.md), [Interviews](api/services/interviews.md), [Content](api/services/content.md), [Social](api/services/social.md)
+- **Services** — [Profiles](api/services/profiles.md), [Conversations](api/services/conversations.md), [Groups](api/services/groups.md), [Interviews](api/services/interviews.md), [Content](api/services/content.md), [Library](api/services/library.md), [Social](api/services/social.md), [Provisioning](api/services/provision.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -57,9 +57,11 @@ nav:
       - Content: api/services/content.md
       - Library: api/services/library.md
       - Social: api/services/social.md
+      - Provisioning: api/services/provision.md
     - Async (aio):
       - Conversations: api/services/aio/conversations.md
       - Groups: api/services/aio/groups.md
       - Interviews: api/services/aio/interviews.md
       - Agentic Resume: api/services/aio/agentic_resume.md
+      - Provisioning: api/services/aio/provision.md
     - OpenAI-compatible chat: api/chat.md


### PR DESCRIPTION
## What

The provisioning methods landed in #57 but never got docs. This adds them.

- New mkdocstrings pages: `docs/api/services/provision.md` (sync) and `docs/api/services/aio/provision.md` (async)
- Wired both into the `mkdocs.yml` nav (Sync + Async sections)
- New **Provisioning** section in the README API Reference table covering `provision_create`, `provision_create_batch`, `provision_send_invites`, `provision_list`
- Updated the `docs/index.md` services list to include Provisioning (and the previously-missing Library)

## Drive-by fix

Dropped the dead `Companies & Roles` link from `docs/index.md` — it pointed at `api/services/companies.md`, which doesn't exist (no companies service in the SDK). This was already failing `mkdocs build --strict`. With it removed, the strict build now passes.

## Verification

- `mkdocs build --strict` passes (exit 0); both new pages render with all four methods.
- README signatures and return-value descriptions verified against `superme_sdk/services/_provision.py` and `aio/_provision.py`.
- code-reviewer + docs-reviewer: no Critical/Warning findings.

## Out of scope (pre-existing, flagging)

- `docs/api/low_level.md` is orphaned — exists on disk but not in nav. Left as-is.
- The async (aio) nav lists fewer services than sync — worth confirming that's intentional.

---
[duy 🐨 d47: i think we're missing the provisioning in sdk docs](https://duy.superme.koala.army/task/019ef868-dc51-722e-b162-d50826505d47)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Document provisioning methods in the SDK API reference
> Adds documentation for four provisioning methods (`provision_create`, `provision_create_batch`, `provision_send_invites`, `provision_list`) in both sync and async variants. Updates [docs/index.md](https://github.com/superme-ai/superme-sdk/pull/58/files#diff-b4d68dc855d0f9476d3f2ee343853bd21bf82ea9960d0cf06661baa244439dd6) and [mkdocs.yml](https://github.com/superme-ai/superme-sdk/pull/58/files#diff-98d0f806abc9af24e6a7c545d3d77e8f9ad57643e27211d7a7b896113e420ed2) to include Provisioning in the navigation, and removes the 'Companies & Roles' link from the services list.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7bcdb87.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new Provisioning section to the API Reference with guidance on creating provisions, batch creation, sending invites, and listing provisions.
  * Added dedicated documentation pages for both synchronous and asynchronous provisioning APIs.
  * Updated the API navigation and service links so Provisioning appears alongside the other service docs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->