### PR TITLE
feat(sdk): provision_get + typed provisioning responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,10 +181,11 @@ make test-live
 
 | Method | Returns | Description |
 |--------|---------|-------------|
-| `provision_create(community_id, *, name, linkedin_url, contact_email, notes, socials, external_urls)` | `dict` | Provision a single community member. Returns a `provision` record with `user_id`, `token`, `claim_url`, and `status`. |
+| `provision_create(community_id, *, name, linkedin_url, contact_email, notes, socials, external_urls)` | `ProvisionCreateResponse` | Provision a single community member. Returns a `provision` record with `user_id`, `token`, `claim_url`, and `status`. |
 | `provision_create_batch(community_id, profiles)` | `list[dict]` | Provision multiple members concurrently (up to 10 in flight). Results match the order of `profiles`; failed items have an `"error"` key instead of `"provision"`. |
-| `provision_send_invites(community_id, user_ids)` | `dict` | Send invite emails to provisioned members. Returns `sent`, `skipped`, and `failed` lists. |
-| `provision_list(community_id)` | `dict` | List all provisions for a community. Returns `provisions` and `count`. |
+| `provision_send_invites(community_id, user_ids)` | `ProvisionInviteResponse` | Send invite emails to provisioned members. Returns `sent`, `skipped`, and `failed` lists. |
+| `provision_list(community_id)` | `ProvisionListResponse` | List all provisions for a community. Returns `provisions` and `count`. |
+| `provision_get(community_id, user_id)` | `ProvisionRecord` | Fetch a single provisioned member by user ID. |
 
 #### OpenAI-compatible interface
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "superme-sdk"
-version = "0.6.0"
+version = "0.7.0"
 description = "Python SDK for SuperMe AI API with OpenAI-compatible interface"
 readme = "README.md"
 authors = [

--- a/superme_sdk/__init__.py
+++ b/superme_sdk/__init__.py
@@ -10,7 +10,17 @@ from .exceptions import (
     APIError,
     MCPError,
 )
-from .models import StreamEvent, StageInfo, InterviewStatus
+from .models import (
+    StreamEvent,
+    StageInfo,
+    InterviewStatus,
+    ProvisionRecord,
+    ProvisionProfile,
+    ProvisionInviteOutcome,
+    ProvisionCreateResponse,
+    ProvisionListResponse,
+    ProvisionInviteResponse,
+)
 
 __version__ = "0.6.0"
 __all__ = [
@@ -29,4 +39,10 @@ __all__ = [
     "StreamEvent",
     "StageInfo",
     "InterviewStatus",
+    "ProvisionRecord",
+    "ProvisionProfile",
+    "ProvisionInviteOutcome",
+    "ProvisionCreateResponse",
+    "ProvisionListResponse",
+    "ProvisionInviteResponse",
 ]

--- a/superme_sdk/__init__.py
+++ b/superme_sdk/__init__.py
@@ -22,7 +22,7 @@ from .models import (
     ProvisionInviteResponse,
 )
 
-__version__ = "0.6.0"
+__version__ = "0.7.0"
 __all__ = [
     "SuperMeClient",
     "AsyncSuperMeClient",

--- a/superme_sdk/models.py
+++ b/superme_sdk/models.py
@@ -48,6 +48,63 @@ class ChatCompletion:
         self.metadata: Optional[dict] = data.get("metadata")
 
 
+class ProvisionRecord(TypedDict, total=False):
+    """A single provisioned member record."""
+
+    user_id: str
+    token: str
+    name: str
+    linkedin_url: Optional[str]
+    contact_email: Optional[str]
+    notes: Optional[str]
+    claim_url: str
+    status: str
+    created_at: Optional[str]
+    claimed_at: Optional[str]
+    invited_at: Optional[str]
+    socials: dict[str, str]
+    doc_count: int
+    audited: bool
+    audited_at: Optional[str]
+    deletion_requested_at: Optional[str]
+    deletion_reason: Optional[str]
+    reused: bool
+
+
+class ProvisionProfile(TypedDict, total=False):
+    """Input profile for :meth:`~superme_sdk.SuperMeClient.provision_create_batch`."""
+
+    name: str
+    linkedin_url: str
+    contact_email: str
+    notes: str
+    socials: dict[str, str]
+    external_urls: list[str]
+
+
+class ProvisionInviteOutcome(TypedDict, total=False):
+    user_id: str
+    reason: str
+
+
+class ProvisionCreateResponse(TypedDict, total=False):
+    success: bool
+    provision: ProvisionRecord
+
+
+class ProvisionListResponse(TypedDict, total=False):
+    success: bool
+    provisions: list[ProvisionRecord]
+    count: int
+
+
+class ProvisionInviteResponse(TypedDict, total=False):
+    success: bool
+    sent: list[str]
+    skipped: list[ProvisionInviteOutcome]
+    failed: list[ProvisionInviteOutcome]
+
+
 class StageInfo(TypedDict, total=False):
     """A single stage from the interview status API."""
 

--- a/superme_sdk/services/_provision.py
+++ b/superme_sdk/services/_provision.py
@@ -7,6 +7,14 @@ from typing import Any, Optional
 
 import httpx
 
+from superme_sdk.models import (
+    ProvisionCreateResponse,
+    ProvisionInviteResponse,
+    ProvisionListResponse,
+    ProvisionProfile,
+    ProvisionRecord,
+)
+
 
 _BATCH_CONCURRENCY = 10
 
@@ -47,7 +55,7 @@ class ProvisionMixin:
         notes: Optional[str] = None,
         socials: Optional[dict[str, str]] = None,
         external_urls: Optional[list[str]] = None,
-    ) -> dict[str, Any]:
+    ) -> ProvisionCreateResponse:
         """Provision a single community member.
 
         Example:
@@ -72,8 +80,7 @@ class ProvisionMixin:
             external_urls: URLs to import into the person's knowledge base.
 
         Returns:
-            Dict with ``provision`` record including ``user_id``, ``token``,
-            ``claim_url``, and ``status``.
+            :class:`~superme_sdk.ProvisionCreateResponse` with the provisioned member record.
         """
         body = _provision_body(
             community_id,
@@ -91,7 +98,7 @@ class ProvisionMixin:
     def provision_create_batch(
         self,
         community_id: str,
-        profiles: list[dict[str, Any]],
+        profiles: list[ProvisionProfile],
     ) -> list[dict[str, Any]]:
         """Provision multiple community members concurrently.
 
@@ -170,7 +177,7 @@ class ProvisionMixin:
         self,
         community_id: str,
         user_ids: list[str],
-    ) -> dict[str, Any]:
+    ) -> ProvisionInviteResponse:
         """Send invite emails to provisioned members.
 
         Example:
@@ -187,7 +194,7 @@ class ProvisionMixin:
             user_ids: List of provisioned user IDs to send invites to.
 
         Returns:
-            Dict with ``sent``, ``skipped``, and ``failed`` lists.
+            :class:`~superme_sdk.ProvisionInviteResponse` with ``sent``, ``skipped``, and ``failed`` lists.
         """
         resp = self._rest_http.post(
             f"/api/v3/provision/{community_id}/invite",
@@ -196,7 +203,7 @@ class ProvisionMixin:
         self._check_rest_response(resp)
         return resp.json()
 
-    def provision_list(self, community_id: str) -> dict[str, Any]:
+    def provision_list(self, community_id: str) -> ProvisionListResponse:
         """List all provisions for a community.
 
         Example:
@@ -210,7 +217,7 @@ class ProvisionMixin:
             community_id: The community to list provisions for.
 
         Returns:
-            Dict with ``provisions`` list and ``count``.
+            :class:`~superme_sdk.ProvisionListResponse` with ``provisions`` list and ``count``.
         """
         resp = self._rest_http.get(
             f"/api/v3/provision/{community_id}",
@@ -218,3 +225,23 @@ class ProvisionMixin:
         )
         self._check_rest_response(resp)
         return resp.json()
+
+    def provision_get(self, community_id: str, user_id: str) -> ProvisionRecord:
+        """Fetch a single provisioned member by user ID.
+
+        Example:
+            ```python
+            record = client.provision_get("community_abc", "user_123")
+            print(record["status"], record["claim_url"])
+            ```
+
+        Args:
+            community_id: The community that owns the provision.
+            user_id: The provisioned user's ID.
+
+        Returns:
+            :class:`~superme_sdk.ProvisionRecord` for the given user.
+        """
+        resp = self._rest_http.get(f"/api/v3/provision/{community_id}/{user_id}")
+        self._check_rest_response(resp)
+        return resp.json()["provision"]

--- a/superme_sdk/services/aio/_provision.py
+++ b/superme_sdk/services/aio/_provision.py
@@ -5,6 +5,14 @@ from __future__ import annotations
 import asyncio
 from typing import Any, Optional
 
+from superme_sdk.models import (
+    ProvisionCreateResponse,
+    ProvisionInviteResponse,
+    ProvisionListResponse,
+    ProvisionProfile,
+    ProvisionRecord,
+)
+
 
 _BATCH_CONCURRENCY = 10
 
@@ -20,7 +28,7 @@ class AsyncProvisionMixin:
         notes: Optional[str] = None,
         socials: Optional[dict[str, str]] = None,
         external_urls: Optional[list[str]] = None,
-    ) -> dict[str, Any]:
+    ) -> ProvisionCreateResponse:
         """Provision a single community member (async).
 
         Args:
@@ -33,8 +41,7 @@ class AsyncProvisionMixin:
             external_urls: URLs to import into the person's knowledge base.
 
         Returns:
-            Dict with ``provision`` record including ``user_id``, ``token``,
-            ``claim_url``, and ``status``.
+            :class:`~superme_sdk.ProvisionCreateResponse` with the provisioned member record.
         """
         body: dict[str, Any] = {
             "community_id": community_id,
@@ -59,7 +66,7 @@ class AsyncProvisionMixin:
     async def provision_create_batch(
         self,
         community_id: str,
-        profiles: list[dict[str, Any]],
+        profiles: list[ProvisionProfile],
     ) -> list[dict[str, Any]]:
         """Provision multiple community members concurrently (async).
 
@@ -94,7 +101,7 @@ class AsyncProvisionMixin:
         self,
         community_id: str,
         user_ids: list[str],
-    ) -> dict[str, Any]:
+    ) -> ProvisionInviteResponse:
         """Send invite emails to provisioned members (async).
 
         Args:
@@ -102,7 +109,7 @@ class AsyncProvisionMixin:
             user_ids: List of provisioned user IDs to send invites to.
 
         Returns:
-            Dict with ``sent``, ``skipped``, and ``failed`` lists.
+            :class:`~superme_sdk.ProvisionInviteResponse` with ``sent``, ``skipped``, and ``failed`` lists.
         """
         resp = await self._async_rest_http.post(
             f"/api/v3/provision/{community_id}/invite",
@@ -111,14 +118,14 @@ class AsyncProvisionMixin:
         self._check_rest_response(resp)
         return resp.json()
 
-    async def provision_list(self, community_id: str) -> dict[str, Any]:
+    async def provision_list(self, community_id: str) -> ProvisionListResponse:
         """List all provisions for a community (async).
 
         Args:
             community_id: The community to list provisions for.
 
         Returns:
-            Dict with ``provisions`` list and ``count``.
+            :class:`~superme_sdk.ProvisionListResponse` with ``provisions`` list and ``count``.
         """
         resp = await self._async_rest_http.get(
             f"/api/v3/provision/{community_id}",
@@ -126,3 +133,25 @@ class AsyncProvisionMixin:
         )
         self._check_rest_response(resp)
         return resp.json()
+
+    async def provision_get(self, community_id: str, user_id: str) -> ProvisionRecord:
+        """Fetch a single provisioned member by user ID (async).
+
+        Example:
+            ```python
+            record = await client.provision_get("community_abc", "user_123")
+            print(record["status"], record["claim_url"])
+            ```
+
+        Args:
+            community_id: The community that owns the provision.
+            user_id: The provisioned user's ID.
+
+        Returns:
+            :class:`~superme_sdk.ProvisionRecord` for the given user.
+        """
+        resp = await self._async_rest_http.get(
+            f"/api/v3/provision/{community_id}/{user_id}"
+        )
+        self._check_rest_response(resp)
+        return resp.json()["provision"]

--- a/uv.lock
+++ b/uv.lock
@@ -600,7 +600,7 @@ wheels = [
 
 [[package]]
 name = "superme-sdk"
-version = "0.5.0"
+version = "0.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary
- Adds `provision_get(community_id, user_id)` (sync + async) hitting the new backend `GET /v3/provision/{community_id}/{user_id}`
- Replaces all `dict[str, Any]` return types on provisioning methods with proper TypedDicts (`ProvisionRecord`, `ProvisionCreateResponse`, `ProvisionListResponse`, `ProvisionInviteResponse`)
- Adds `ProvisionProfile` input type for `provision_create_batch`
- All new types exported from `superme_sdk` top-level

## Notes
- `provision_get` returns `ProvisionRecord` directly (unwrapped from the `{"provision": ...}` envelope)
- Batch output stays `list[dict]` — each item is either a `ProvisionCreateResponse` or `{"error": str}`, which doesn't map cleanly to a single TypedDict
- No public shape changes

## Test plan
- [ ] 150 existing tests pass
- [ ] `client.provision_get("community_id", "user_id")` returns typed record
- [ ] Async variant works identically

---
[duy 🐨 0f9: sdk single provisioning fetch](https://duy.superme.koala.army/task/019f126f-e4c5-7aa9-b5bc-c07edac6b0f9)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `provision_get` method and typed provisioning response models to the SDK
> - Adds `provision_get(community_id, user_id)` to both `ProvisionMixin` and `AsyncProvisionMixin`, issuing a GET to `/api/v3/provision/{community_id}/{user_id}` and returning the `ProvisionRecord` payload.
> - Introduces typed `TypedDict` models (`ProvisionRecord`, `ProvisionProfile`, `ProvisionCreateResponse`, `ProvisionListResponse`, `ProvisionInviteResponse`, `ProvisionInviteOutcome`) in [models.py](https://github.com/superme-ai/superme-sdk/pull/59/files#diff-18691907034522b4702c164a7d1d276bc9d374b78b5ef97c6624a88754b1d9a3) and exports them from the top-level package.
> - Updates existing provisioning method signatures to use the new typed models instead of `dict[str, Any]`.
> - Bumps the package version from `0.6.0` to `0.7.0`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9898a8c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->