### PR TITLE
feat(sdk): typed PartnerStreamChunk + lighter streaming docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ make test-live
 |--------|---------|-------------|
 | `ask(question, username, conversation_id, max_tokens, incognito, stream=False)` | `str` \| `generator` | Ask a question to a user's SuperMe agent. Returns the answer text, or — with `stream=True` — a generator of SSE chunk dicts (`content` / `tool` / `done` / `error`, via `POST /partner/ask`). `incognito`/`max_tokens` apply to non-streaming only. |
 | ~~`ask_with_history(messages, username, *, conversation_id, max_tokens, incognito)`~~ | `(str, str\|None)` | **Deprecated** — kept for backward compatibility. Use `ask` with `conversation_id` instead. Only the last user message is sent; the rest of the list is ignored. |
-| `ask_my_agent(question, *, conversation_id, stream=False)` | `dict` \| `generator` | Talk to your own SuperMe AI agent. Returns `{"response": ..., "conversation_id": ...}`, or — with `stream=True` — a generator of typed turn-event dicts (`turn_started`, `content`, `tool_call`, `turn_completed`, ..., via `POST /partner/agent`). |
+| `ask_my_agent(question, *, conversation_id, stream=False)` | `dict` \| `generator` | Talk to your own SuperMe AI agent. Returns `{"response": ..., "conversation_id": ...}`, or — with `stream=True` — a generator of partner chunk dicts (`content` / `tool` / `done` / `error`, via `POST /partner/agent`) — the same shape as `ask`. |
 
 `AsyncSuperMeClient` mirrors these: with `stream=True`, `ask` / `ask_my_agent` return async generators (`async for`); otherwise they are awaitable (`await`). `get_profile`, `get_user_details`, `find_user_by_name`, `find_users_by_names`, and `find_users_on_topic` are awaitable.
 
@@ -212,10 +212,10 @@ for chunk in client.ask("What is PMF?", username="ludo", stream=True):
     elif chunk["type"] == "done":
         conversation_id = chunk["conversation_id"]
 
-# Stream your own agent (richer turn events: tool calls, messages, ...)
-for evt in client.ask_my_agent("Summarise my last 3 posts", stream=True):
-    if evt["type"] == "content":
-        print(evt["content"], end="", flush=True)
+# Stream your own agent — same chunk shape (content / tool / done / error)
+for chunk in client.ask_my_agent("Summarise my last 3 posts", stream=True):
+    if chunk["type"] == "content":
+        print(chunk["text"], end="", flush=True)
 ```
 
 Async (`AsyncSuperMeClient`) — `stream=True` returns an async generator:

--- a/docs/api/streaming.md
+++ b/docs/api/streaming.md
@@ -1,0 +1,27 @@
+# Streaming events
+
+Both `ask(stream=True)` and `ask_my_agent(stream=True)` yield the same partner
+chunks over SSE. At runtime each chunk is a plain `dict` — discriminate on
+`["type"]`. The stream stops after `done` or `error`.
+
+| `type` | fields | meaning |
+|--------|--------|---------|
+| `content` | `text: str` | a piece of the answer text |
+| `tool` | `label: str` | a tool the agent is calling (e.g. `"Searching the web"`) |
+| `done` | `conversation_id: str` | finished — pass `conversation_id` back to continue the thread |
+| `error` | `message: str` | the turn failed |
+
+```python
+for chunk in client.ask("What is PMF?", username="ludo", stream=True):
+    if chunk["type"] == "content":
+        print(chunk["text"], end="", flush=True)
+    elif chunk["type"] == "done":
+        conversation_id = chunk["conversation_id"]
+```
+
+For static typing, import `PartnerStreamChunk` (a union of `TypedDict`s) and its
+members from `superme_sdk`:
+
+```python
+from superme_sdk import PartnerStreamChunk, ContentChunk, ToolChunk, DoneChunk, ErrorChunk
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -36,6 +36,7 @@ plugins:
             show_source: true
             show_signature_annotations: true
             separate_signature: true
+            show_overloads: false
             members_order: source
 
 markdown_extensions:
@@ -49,6 +50,7 @@ nav:
     - Authentication: api/auth.md
     - Client: api/client.md
     - Models: api/models.md
+    - Streaming events: api/streaming.md
     - Sync:
       - Conversations: api/services/conversations.md
       - Profiles: api/services/profiles.md

--- a/superme_sdk/__init__.py
+++ b/superme_sdk/__init__.py
@@ -20,6 +20,13 @@ from .models import (
     ProvisionListResponse,
     ProvisionInviteResponse,
 )
+from .streaming import (
+    PartnerStreamChunk,
+    ContentChunk,
+    ToolChunk,
+    DoneChunk,
+    ErrorChunk,
+)
 
 __version__ = "0.8.0"
 __all__ = [
@@ -43,4 +50,9 @@ __all__ = [
     "ProvisionCreateResponse",
     "ProvisionListResponse",
     "ProvisionInviteResponse",
+    "PartnerStreamChunk",
+    "ContentChunk",
+    "ToolChunk",
+    "DoneChunk",
+    "ErrorChunk",
 ]

--- a/superme_sdk/_transport/_terminals.py
+++ b/superme_sdk/_transport/_terminals.py
@@ -1,11 +1,23 @@
 """Terminal SSE event-type sets for the partner streaming endpoints.
 
 Shared by the sync and async conversation mixins so the two never drift.
-Values mirror the backend ``Literal``s: ``/partner/ask`` emits a final
-``done``/``error`` chunk; ``/partner/agent`` ends on a turn lifecycle event.
+
+Both endpoints converge on the thin partner contract — a final ``done`` or
+``error`` chunk (see :data:`~superme_sdk.streaming.PartnerStreamChunk`).
+``/partner/agent`` historically ended instead on a turn-lifecycle event
+(``turn_completed``/``turn_failed``/``turn_interrupted``); backend PR #5643
+collapses it to the thin ``done``/``error`` shape. We keep the legacy names in
+the agent set so the stream still terminates against a backend that hasn't
+deployed #5643 yet — whichever terminal arrives first stops the generator, so
+it never hangs past the end of a turn. The public type catalog only documents
+the thin ``done``/``error`` terminals.
 """
 
 from __future__ import annotations
 
 ASK_TERMINAL = frozenset({"done", "error"})
-AGENT_TERMINAL = frozenset({"turn_completed", "turn_failed", "turn_interrupted"})
+# Thin terminals (post-#5643) plus the legacy turn-lifecycle events, so the
+# agent stream terminates correctly whether or not #5643 has shipped.
+AGENT_TERMINAL = ASK_TERMINAL | frozenset(
+    {"turn_completed", "turn_failed", "turn_interrupted"}
+)

--- a/superme_sdk/services/_conversations.py
+++ b/superme_sdk/services/_conversations.py
@@ -7,6 +7,7 @@ from collections.abc import Iterator
 from typing import Any, Literal, Optional, overload
 
 from .._transport._terminals import AGENT_TERMINAL, ASK_TERMINAL
+from ..streaming import PartnerStreamChunk
 
 
 class ConversationsMixin:
@@ -33,7 +34,7 @@ class ConversationsMixin:
         *,
         stream: Literal[True],
         **kwargs: Any,
-    ) -> Iterator[dict]: ...
+    ) -> Iterator[PartnerStreamChunk]: ...
 
     def ask(
         self,
@@ -44,7 +45,7 @@ class ConversationsMixin:
         incognito: bool = False,
         stream: bool = False,
         **kwargs: Any,
-    ) -> str | Iterator[dict]:
+    ) -> str | Iterator[PartnerStreamChunk]:
         """Ask a single question to a user's SuperMe agent.
 
         Example:
@@ -222,7 +223,7 @@ class ConversationsMixin:
         *,
         conversation_id: Optional[str] = ...,
         stream: Literal[True],
-    ) -> Iterator[dict]: ...
+    ) -> Iterator[PartnerStreamChunk]: ...
 
     def ask_my_agent(
         self,
@@ -230,7 +231,7 @@ class ConversationsMixin:
         *,
         conversation_id: Optional[str] = None,
         stream: bool = False,
-    ) -> dict | Iterator[dict]:
+    ) -> dict | Iterator[PartnerStreamChunk]:
         """Talk to your own SuperMe AI agent.
 
         Example:
@@ -238,24 +239,24 @@ class ConversationsMixin:
             result = client.ask_my_agent("Summarise my last 3 posts")
             print(result["response"])
 
-            # streaming (yields typed turn-event dicts over SSE)
-            for evt in client.ask_my_agent("Summarise my posts", stream=True):
-                if evt["type"] == "content":
-                    print(evt["content"], end="", flush=True)
+            # streaming (yields partner chunk dicts over SSE)
+            for chunk in client.ask_my_agent("Summarise my posts", stream=True):
+                if chunk["type"] == "content":
+                    print(chunk["text"], end="", flush=True)
             ```
 
         Args:
             question: Your message to the agent.
             conversation_id: Continue an existing conversation.
-            stream: If True, return a generator of SSE turn-event dicts instead
-                of the final dict.
+            stream: If True, return a generator of SSE chunk dicts instead of
+                the final dict.
 
         Returns:
             Dict with ``response`` and ``conversation_id``, or — when
-            ``stream=True`` — a generator yielding typed turn-event dicts
-            (``turn_started``, ``content``, ``message``, ``tool_call``,
-            ``tool_result``, ``turn_completed``, ``turn_failed``, ...), stopping
-            after a terminal event.
+            ``stream=True`` — a generator yielding partner chunk dicts (``type``:
+            ``content``/``tool``/``done``/``error`` — see
+            :data:`~superme_sdk.streaming.PartnerStreamChunk`), stopping after
+            ``done`` or ``error``.
         """
         if stream:
             body: dict[str, Any] = {"question": question, "stream": True}

--- a/superme_sdk/services/aio/_conversations.py
+++ b/superme_sdk/services/aio/_conversations.py
@@ -6,6 +6,7 @@ from collections.abc import AsyncIterator, Awaitable
 from typing import Any, Literal, Optional, overload
 
 from ..._transport._terminals import AGENT_TERMINAL, ASK_TERMINAL
+from ...streaming import PartnerStreamChunk
 
 
 class AsyncConversationsMixin:
@@ -39,7 +40,7 @@ class AsyncConversationsMixin:
         *,
         conversation_id: Optional[str] = ...,
         stream: Literal[True],
-    ) -> AsyncIterator[dict]: ...
+    ) -> AsyncIterator[PartnerStreamChunk]: ...
 
     def ask(
         self,
@@ -48,7 +49,7 @@ class AsyncConversationsMixin:
         *,
         conversation_id: Optional[str] = None,
         stream: bool = False,
-    ) -> Awaitable[str] | AsyncIterator[dict]:
+    ) -> Awaitable[str] | AsyncIterator[PartnerStreamChunk]:
         """Ask a single question to a user's SuperMe agent (async).
 
         Example:
@@ -105,7 +106,7 @@ class AsyncConversationsMixin:
         *,
         conversation_id: Optional[str] = ...,
         stream: Literal[True],
-    ) -> AsyncIterator[dict]: ...
+    ) -> AsyncIterator[PartnerStreamChunk]: ...
 
     def ask_my_agent(
         self,
@@ -113,22 +114,23 @@ class AsyncConversationsMixin:
         *,
         conversation_id: Optional[str] = None,
         stream: bool = False,
-    ) -> Awaitable[dict] | AsyncIterator[dict]:
+    ) -> Awaitable[dict] | AsyncIterator[PartnerStreamChunk]:
         """Talk to your own SuperMe AI agent (async).
 
         Example:
             ```python
             result = await client.ask_my_agent("Summarise my last 3 posts")
 
-            async for evt in client.ask_my_agent("Summarise my posts", stream=True):
-                if evt["type"] == "content":
-                    print(evt["content"], end="", flush=True)
+            async for chunk in client.ask_my_agent("Summarise my posts", stream=True):
+                if chunk["type"] == "content":
+                    print(chunk["text"], end="", flush=True)
             ```
 
         Returns:
             An awaitable resolving to a dict with ``response`` and
             ``conversation_id``, or — when ``stream=True`` — an async generator
-            of typed turn-event dicts (stops after a terminal event).
+            of partner chunk dicts (``content``/``tool``/``done``/``error``),
+            stopping after ``done`` or ``error``.
         """
         if stream:
             body: dict[str, Any] = {"question": question, "stream": True}

--- a/superme_sdk/streaming.py
+++ b/superme_sdk/streaming.py
@@ -1,0 +1,46 @@
+"""Typed shapes for the SSE chunks yielded by streaming calls.
+
+Both ``ask(..., stream=True)`` and ``ask_my_agent(..., stream=True)`` yield the
+same four partner chunk types — see the partner API docs (the source of truth):
+https://api.superme.ai/partner/docs
+
+These are ``TypedDict``s: at runtime each chunk is a plain ``dict`` (zero
+behavior change), but type checkers and IDEs can tell you the exact shape.
+Discriminate on ``type``; the stream stops after ``done`` or ``error``.
+"""
+
+from __future__ import annotations
+
+from typing import Literal, TypedDict, Union
+
+
+class ContentChunk(TypedDict):
+    """A piece of the answer text."""
+
+    type: Literal["content"]
+    text: str
+
+
+class ToolChunk(TypedDict):
+    """A tool the agent is calling (human-readable label, e.g. "Searching the web")."""
+
+    type: Literal["tool"]
+    label: str
+
+
+class DoneChunk(TypedDict):
+    """Terminal: finished. Use ``conversation_id`` to continue the thread."""
+
+    type: Literal["done"]
+    conversation_id: str
+
+
+class ErrorChunk(TypedDict):
+    """Terminal: the turn failed."""
+
+    type: Literal["error"]
+    message: str
+
+
+PartnerStreamChunk = Union[ContentChunk, ToolChunk, DoneChunk, ErrorChunk]
+"""Every chunk a partner stream can yield. Stops after ``done`` or ``error``."""

--- a/tests/test_partner_streaming.py
+++ b/tests/test_partner_streaming.py
@@ -149,6 +149,12 @@ class TestAskStream:
 
 
 class TestAskMyAgentStream:
+    # /partner/agent has two wire eras. Backend PR #5643 translates internal
+    # turn events into the thin PartnerStreamChunk contract (content/tool/done/
+    # error) — the documented shape, see ``test_stops_after_thin_done_chunk``.
+    # Before #5643 deploys it still emits raw turn-lifecycle events; the tests
+    # below pin that the SDK terminates correctly against that legacy shape too
+    # (AGENT_TERMINAL is the union of both, so neither era hangs).
     @respx.mock
     def test_posts_to_partner_agent_and_yields_turn_events(self):
         route = respx.post(f"{PARTNER_BASE}/partner/agent").mock(
@@ -190,6 +196,30 @@ class TestAskMyAgentStream:
             events = list(client.ask_my_agent("hi", stream=True))
         assert len(events) == 1
         assert events[0]["type"] == "turn_failed"
+
+    @respx.mock
+    def test_stops_after_thin_done_chunk(self):
+        # Post-#5643: /partner/agent emits the thin done/error contract — the
+        # stream must stop on `done` and not hang past it.
+        respx.post(f"{PARTNER_BASE}/partner/agent").mock(
+            return_value=httpx.Response(
+                200,
+                content=_sse(
+                    {"type": "tool", "label": "Searching the web"},
+                    {"type": "content", "text": "hi"},
+                    {"type": "done", "conversation_id": "c1"},
+                    {"type": "content", "text": "after"},
+                ),
+                headers={"content-type": "text/event-stream"},
+            )
+        )
+        with SuperMeClient(api_key=FAKE_JWT) as client:
+            events = list(client.ask_my_agent("hi", stream=True))
+        assert [e["type"] for e in events] == ["tool", "content", "done"]
+        # PartnerStreamChunk field shapes, matching backend #5643's translator.
+        assert events[0]["label"] == "Searching the web"
+        assert events[1]["text"] == "hi"
+        assert events[2]["conversation_id"] == "c1"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Why

Follow-up to #61. That PR merged the streaming **functionality** (`_iter_sse`, `_partner_http`, `ask`/`ask_my_agent` with `stream=True` over the partner SSE endpoints) — but the squash landed an earlier snapshot and dropped the final typing/docs layer. This PR adds that layer on top of current `main`.

## What

- **`superme_sdk/streaming.py`** — `PartnerStreamChunk`, a union of 4 `TypedDict`s: `ContentChunk{text}` / `ToolChunk{label}` / `DoneChunk{conversation_id}` / `ErrorChunk{message}`. Plain dicts at runtime (zero behavior change), but users now have a typed catalog of which stream events exist.
- **Typed returns** — `ask` / `ask_my_agent` (sync + async) use `@overload` on `stream=`, so the static return is `str`/`dict` for `stream=False` and `Iterator` / `AsyncIterator[PartnerStreamChunk]` for `stream=True`.
- **`__init__`** exports `PartnerStreamChunk` and members.
- **`docs/api/streaming.md`** — compact 4-row chunk table (replaces the heavy auto-render) + example + import line.
- **README** streaming section + mkdocs nav entry.
- **`AGENT_TERMINAL`** is the **union** of the thin terminals (`done`/`error`) and the legacy turn-lifecycle events, so the agent stream stops correctly before *and* after backend #5643 — no hang past a turn's end in either era.

## Matches the thin partner contract (verified against backend #5643)

Both `/partner/ask` and `/partner/agent` emit the same thin 4-chunk shape. For `/partner/agent` this is delivered by superme-ai/superme-backend#5643's `_agent_event_to_chunk` translator, which maps internal turn events → `PartnerStreamChunk` exactly:

| internal turn event | partner chunk |
|---|---|
| `content` | `ContentChunk(text=…)` |
| `tool_call` | `ToolChunk(label=…)` |
| `turn_completed` | `DoneChunk(conversation_id=…)` |
| `turn_failed` / `turn_interrupted` | `ErrorChunk(message=…)` |

The SDK types mirror that translator and its `partner_docs` table.

## Review resolution

The two automated reviews split on `/partner/agent`'s wire shape:
- **architecture-reviewer** flagged a terminal split-brain (types say `done`/`error`, runtime stopped on turn events) — **correct**, fixed via the union terminal above.
- **code-reviewer** flagged the types as the *wrong shape* (turn events, not thin) — based on **pre-#5643 state** (it read current `main` + the stale `partner-agent-plan.md`). #5643 makes `/partner/agent` emit the thin shape, so the types are right for the released contract; the transition is handled by the union terminal and pinned by tests.

## ⚠️ Deploy coupling

Cut the SDK release **in lockstep with backend #5643**. Until #5643 deploys, `/partner/agent` still emits the raw turn shape (field `content`, terminal `turn_completed`); the union terminal keeps the stream from hanging, but the documented `chunk["text"]` / `done` shape only holds once #5643 is live.

## Tests

`155 passed` (mocked, no network). `tests/test_partner_streaming.py` now pins: agent stream stops on a thin `done` chunk, the `tool`/`content`/`done` field shapes match #5643, and the legacy turn-event path still terminates (transition-era).

## Docs proof

Screenshots in the task artifacts (`sdk-streaming-proof/`): `docs-streaming-events.png` (light chunk table), `docs-ask.png` / `docs-ask_my_agent.png` (single clean `-> str | Iterator[PartnerStreamChunk]` signature, no triple-stacked overloads).

---
[duy 🐨 083: expose thin API for ask my agent plus all ask features](https://duy.superme.koala.army/task/019f1223-6a09-7005-9d88-653eb6027083)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add typed `PartnerStreamChunk` union and fix agent stream termination on `done`/`error` events
> - Adds `ContentChunk`, `ToolChunk`, `DoneChunk`, and `ErrorChunk` TypedDicts in [`superme_sdk/streaming.py`](https://github.com/superme-ai/superme-sdk/pull/62/files#diff-ef40587cfc4c67d3a8a59e8b7b708f9d2b13aeeb806c6e08baccbf2bb9a985a1), unified as `PartnerStreamChunk`, and exports them from the package root.
> - Updates `ask` type hints in both sync and async `ConversationsMixin` to return `Iterator[PartnerStreamChunk]` / `AsyncIterator[PartnerStreamChunk]` when `stream=True`.
> - Fixes `AGENT_TERMINAL` in [`superme_sdk/_transport/_terminals.py`](https://github.com/superme-ai/superme-sdk/pull/62/files#diff-523279697abe27302032d32ab4e6c206fa24dc65b108e0200d95edc9f9e623ff) to include `'done'` and `'error'` so agent streams terminate correctly on those events.
> - Adds a streaming events docs page and a regression test covering `done`/`tool`/`content` chunk shapes from the `/partner/agent` endpoint.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 51b8a9e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->