### PR TITLE
docs(sdk): fix Returns rendering — one row, not one per line

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -33,6 +33,10 @@ plugins:
         python:
           options:
             docstring_style: google
+            docstring_options:
+              # Treat each "Returns:" block as one item; otherwise griffe splits
+              # a wrapped multi-line return description into one table row per line.
+              returns_multiple_items: false
             show_source: true
             show_signature_annotations: true
             separate_signature: true


### PR DESCRIPTION
## Bug

On the rendered docs (e.g. [async conversations](https://sdkdocs.superme.ai/api/services/aio/conversations/)), the `ask` / `ask_my_agent` **Returns:** block rendered as a separate table row for *each wrapped line* of the description — 4 rows of the same `Awaitable[dict] | AsyncIterator[PartnerStreamChunk]` type instead of one.

## Cause

griffe's Google docstring parser defaults `returns_multiple_items` to `true`, so a multi-line `Returns:` block is parsed as multiple returned items (one per line).

## Fix

One line in `mkdocs.yml` — `docstring_options: { returns_multiple_items: false }` — so each `Returns:` block is a single item/row. Docs-only; no code or behavior change.

## Proof

Rebuilt locally; the Returns section now renders as a single row. Screenshot: `artifacts/sdk-streaming-proof/docs-returns-fixed.png`.

---
[duy 🐨 083: expose thin API for ask my agent plus all ask features](https://duy.superme.koala.army/task/019f1223-6a09-7005-9d88-653eb6027083)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `Returns` block rendering to display as a single row in generated docs
> Sets `returns_multiple_items: false` in the mkdocstrings Python handler config in [mkdocs.yml](https://github.com/superme-ai/superme-sdk/pull/63/files#diff-98d0f806abc9af24e6a7c545d3d77e8f9ad57643e27211d7a7b896113e420ed2). Without this, multi-line return descriptions are split into multiple table rows in the generated documentation.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0ba174c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->