### PR TITLE
Cut dead MCP/partner surface: ask_my_agent + get_workgroup

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,9 +128,8 @@ make test-live
 |--------|---------|-------------|
 | `ask(question, username, conversation_id, max_tokens, incognito, stream=False)` | `str` \| `generator` | Ask a question to a user's SuperMe agent. Returns the answer text, or — with `stream=True` — a generator of SSE chunk dicts (`content` / `tool` / `done` / `error`, via `POST /partner/ask`). `incognito`/`max_tokens` apply to non-streaming only. |
 | ~~`ask_with_history(messages, username, *, conversation_id, max_tokens, incognito)`~~ | `(str, str\|None)` | **Deprecated** — kept for backward compatibility. Use `ask` with `conversation_id` instead. Only the last user message is sent; the rest of the list is ignored. |
-| `ask_my_agent(question, *, conversation_id, stream=False)` | `dict` \| `generator` | Talk to your own SuperMe AI agent. Returns `{"response": ..., "conversation_id": ...}`, or — with `stream=True` — a generator of partner chunk dicts (`content` / `tool` / `done` / `error`, via `POST /partner/agent`) — the same shape as `ask`. |
 
-`AsyncSuperMeClient` mirrors these: with `stream=True`, `ask` / `ask_my_agent` return async generators (`async for`); otherwise they are awaitable (`await`). `get_profile`, `get_user_details`, `find_user_by_name`, `find_users_by_names`, and `find_users_on_topic` are awaitable.
+`AsyncSuperMeClient` mirrors these: with `stream=True`, `ask` returns an async generator (`async for`); otherwise it is awaitable (`await`). `get_profile`, `get_user_details`, `find_user_by_name`, `find_users_by_names`, and `find_users_on_topic` are awaitable.
 
 #### Profiles & search
 
@@ -201,7 +200,7 @@ print(response.metadata["conversation_id"])
 ### Streaming
 
 Pass `stream=True` to stream tokens as they're generated over SSE. `ask`
-targets another user's agent; `ask_my_agent` targets your own.
+targets a user's agent.
 
 ```python
 # Stream a question to a user's agent
@@ -211,11 +210,6 @@ for chunk in client.ask("What is PMF?", username="ludo", stream=True):
         print(chunk["text"], end="", flush=True)
     elif chunk["type"] == "done":
         conversation_id = chunk["conversation_id"]
-
-# Stream your own agent — same chunk shape (content / tool / done / error)
-for chunk in client.ask_my_agent("Summarise my last 3 posts", stream=True):
-    if chunk["type"] == "content":
-        print(chunk["text"], end="", flush=True)
 ```
 
 Async (`AsyncSuperMeClient`) — `stream=True` returns an async generator:

--- a/docs/api/services/conversations.md
+++ b/docs/api/services/conversations.md
@@ -4,6 +4,5 @@
     options:
       members:
         - ask
-        - ask_my_agent
       show_root_heading: false
       show_root_toc_entry: false

--- a/docs/api/streaming.md
+++ b/docs/api/streaming.md
@@ -1,8 +1,8 @@
 # Streaming events
 
-Both `ask(stream=True)` and `ask_my_agent(stream=True)` yield the same partner
-chunks over SSE. At runtime each chunk is a plain `dict` — discriminate on
-`["type"]`. The stream stops after `done` or `error`.
+`ask(stream=True)` yields partner chunks over SSE. At runtime each chunk is a
+plain `dict` — discriminate on `["type"]`. The stream stops after `done` or
+`error`.
 
 | `type` | fields | meaning |
 |--------|--------|---------|

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "superme-sdk"
-version = "0.8.0"
+version = "0.9.0"
 description = "Python SDK for SuperMe AI API with OpenAI-compatible interface"
 readme = "README.md"
 authors = [

--- a/superme_sdk/__init__.py
+++ b/superme_sdk/__init__.py
@@ -28,7 +28,7 @@ from .streaming import (
     ErrorChunk,
 )
 
-__version__ = "0.8.0"
+__version__ = "0.9.0"
 __all__ = [
     "SuperMeClient",
     "AsyncSuperMeClient",

--- a/superme_sdk/_transport/_terminals.py
+++ b/superme_sdk/_transport/_terminals.py
@@ -1,23 +1,13 @@
-"""Terminal SSE event-type sets for the partner streaming endpoints.
+"""Terminal SSE event-type set for the partner streaming endpoint.
 
 Shared by the sync and async conversation mixins so the two never drift.
 
-Both endpoints converge on the thin partner contract — a final ``done`` or
+``/partner/ask`` converges on the thin partner contract — a final ``done`` or
 ``error`` chunk (see :data:`~superme_sdk.streaming.PartnerStreamChunk`).
-``/partner/agent`` historically ended instead on a turn-lifecycle event
-(``turn_completed``/``turn_failed``/``turn_interrupted``); backend PR #5643
-collapses it to the thin ``done``/``error`` shape. We keep the legacy names in
-the agent set so the stream still terminates against a backend that hasn't
-deployed #5643 yet — whichever terminal arrives first stops the generator, so
-it never hangs past the end of a turn. The public type catalog only documents
-the thin ``done``/``error`` terminals.
+Whichever terminal arrives first stops the generator, so it never hangs past
+the end of a turn.
 """
 
 from __future__ import annotations
 
 ASK_TERMINAL = frozenset({"done", "error"})
-# Thin terminals (post-#5643) plus the legacy turn-lifecycle events, so the
-# agent stream terminates correctly whether or not #5643 has shipped.
-AGENT_TERMINAL = ASK_TERMINAL | frozenset(
-    {"turn_completed", "turn_failed", "turn_interrupted"}
-)

--- a/superme_sdk/client.py
+++ b/superme_sdk/client.py
@@ -201,8 +201,8 @@ class AsyncSuperMeClient(
     Example::
 
         async with AsyncSuperMeClient(api_key="your-superme-api-key") as client:
-            result = await client.ask_my_agent("Summarise my last 3 posts")
-            print(result["response"])
+            answer = await client.ask("What is PMF?", username="ludo")
+            print(answer)
 
             async for event in client.stream_interview("interview_abc123"):
                 print(event)

--- a/superme_sdk/services/_conversations.py
+++ b/superme_sdk/services/_conversations.py
@@ -6,7 +6,7 @@ import warnings
 from collections.abc import Iterator
 from typing import Any, Literal, Optional, overload
 
-from .._transport._terminals import AGENT_TERMINAL, ASK_TERMINAL
+from .._transport._terminals import ASK_TERMINAL
 from ..streaming import PartnerStreamChunk
 
 
@@ -206,70 +206,3 @@ class ConversationsMixin:
         )
         data = self._mcp_request("tools/list", {})
         return data.get("tools", [])
-
-    @overload
-    def ask_my_agent(
-        self,
-        question: str,
-        *,
-        conversation_id: Optional[str] = ...,
-        stream: Literal[False] = ...,
-    ) -> dict: ...
-
-    @overload
-    def ask_my_agent(
-        self,
-        question: str,
-        *,
-        conversation_id: Optional[str] = ...,
-        stream: Literal[True],
-    ) -> Iterator[PartnerStreamChunk]: ...
-
-    def ask_my_agent(
-        self,
-        question: str,
-        *,
-        conversation_id: Optional[str] = None,
-        stream: bool = False,
-    ) -> dict | Iterator[PartnerStreamChunk]:
-        """Talk to your own SuperMe AI agent.
-
-        Example:
-            ```python
-            result = client.ask_my_agent("Summarise my last 3 posts")
-            print(result["response"])
-
-            # streaming (yields partner chunk dicts over SSE)
-            for chunk in client.ask_my_agent("Summarise my posts", stream=True):
-                if chunk["type"] == "content":
-                    print(chunk["text"], end="", flush=True)
-            ```
-
-        Args:
-            question: Your message to the agent.
-            conversation_id: Continue an existing conversation.
-            stream: If True, return a generator of SSE chunk dicts instead of
-                the final dict.
-
-        Returns:
-            Dict with ``response`` and ``conversation_id``, or — when
-            ``stream=True`` — a generator yielding partner chunk dicts (``type``:
-            ``content``/``tool``/``done``/``error`` — see
-            :data:`~superme_sdk.streaming.PartnerStreamChunk`), stopping after
-            ``done`` or ``error``.
-        """
-        if stream:
-            body: dict[str, Any] = {"question": question, "stream": True}
-            if conversation_id:
-                body["conversation_id"] = conversation_id
-            return self._iter_sse(
-                self._partner_http,
-                "POST",
-                "/partner/agent",
-                json=body,
-                is_terminal=lambda o: o.get("type") in AGENT_TERMINAL,
-            )
-        args: dict[str, Any] = {"question": question}
-        if conversation_id:
-            args["conversation_id"] = conversation_id
-        return self._mcp_tool_call("ask_my_agent", args)

--- a/superme_sdk/services/_workgroups.py
+++ b/superme_sdk/services/_workgroups.py
@@ -31,24 +31,6 @@ class WorkgroupsMixin:
             return workgroups if isinstance(workgroups, list) else []
         return []
 
-    def get_workgroup(self, workgroup_id: str) -> Optional[dict]:
-        """Get a single workgroup by ID.
-
-        Example:
-            ```python
-            workgroup = client.get_workgroup("abc123")
-            for m in workgroup["members"]:
-                print(m["user_id"], m["name"])
-            ```
-
-        Returns:
-            Workgroup dict, or ``None`` if no workgroup with that ID exists.
-        """
-        result = self._mcp_tool_call("workgroup_read", {"workgroup_id": workgroup_id})
-        if isinstance(result, dict) and "error" not in result:
-            return result
-        return None
-
     def create_workgroup(
         self,
         name: str,

--- a/superme_sdk/services/aio/_conversations.py
+++ b/superme_sdk/services/aio/_conversations.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from collections.abc import AsyncIterator, Awaitable
 from typing import Any, Literal, Optional, overload
 
-from ..._transport._terminals import AGENT_TERMINAL, ASK_TERMINAL
+from ..._transport._terminals import ASK_TERMINAL
 from ...streaming import PartnerStreamChunk
 
 
@@ -89,61 +89,3 @@ class AsyncConversationsMixin:
         self._check_rest_response(resp)
         data = resp.json()
         return data.get("answer", "") if isinstance(data, dict) else ""
-
-    @overload
-    def ask_my_agent(
-        self,
-        question: str,
-        *,
-        conversation_id: Optional[str] = ...,
-        stream: Literal[False] = ...,
-    ) -> Awaitable[dict]: ...
-
-    @overload
-    def ask_my_agent(
-        self,
-        question: str,
-        *,
-        conversation_id: Optional[str] = ...,
-        stream: Literal[True],
-    ) -> AsyncIterator[PartnerStreamChunk]: ...
-
-    def ask_my_agent(
-        self,
-        question: str,
-        *,
-        conversation_id: Optional[str] = None,
-        stream: bool = False,
-    ) -> Awaitable[dict] | AsyncIterator[PartnerStreamChunk]:
-        """Talk to your own SuperMe AI agent (async).
-
-        Example:
-            ```python
-            result = await client.ask_my_agent("Summarise my last 3 posts")
-
-            async for chunk in client.ask_my_agent("Summarise my posts", stream=True):
-                if chunk["type"] == "content":
-                    print(chunk["text"], end="", flush=True)
-            ```
-
-        Returns:
-            An awaitable resolving to a dict with ``response`` and
-            ``conversation_id``, or — when ``stream=True`` — an async generator
-            of partner chunk dicts (``content``/``tool``/``done``/``error``),
-            stopping after ``done`` or ``error``.
-        """
-        if stream:
-            body: dict[str, Any] = {"question": question, "stream": True}
-            if conversation_id:
-                body["conversation_id"] = conversation_id
-            return self._aiter_sse(
-                self._async_partner_http,
-                "POST",
-                "/partner/agent",
-                json=body,
-                is_terminal=lambda o: o.get("type") in AGENT_TERMINAL,
-            )
-        args: dict[str, Any] = {"question": question}
-        if conversation_id:
-            args["conversation_id"] = conversation_id
-        return self._async_mcp_tool_call("ask_my_agent", args)

--- a/superme_sdk/services/aio/_workgroups.py
+++ b/superme_sdk/services/aio/_workgroups.py
@@ -21,15 +21,6 @@ class AsyncWorkgroupsMixin:
             return groups if isinstance(groups, list) else []
         return []
 
-    async def get_workgroup(self, workgroup_id: str) -> Optional[dict]:
-        """Get a single workgroup by ID (async)."""
-        result = await self._async_mcp_tool_call(
-            "workgroup_read", {"workgroup_id": workgroup_id}
-        )
-        if isinstance(result, dict) and "error" not in result:
-            return result
-        return None
-
     async def create_workgroup(
         self,
         name: str,

--- a/superme_sdk/streaming.py
+++ b/superme_sdk/streaming.py
@@ -1,7 +1,7 @@
 """Typed shapes for the SSE chunks yielded by streaming calls.
 
-Both ``ask(..., stream=True)`` and ``ask_my_agent(..., stream=True)`` yield the
-same four partner chunk types — see the partner API docs (the source of truth):
+``ask(..., stream=True)`` yields these four partner chunk types — see the
+partner API docs (the source of truth):
 https://api.superme.ai/partner/docs
 
 These are ``TypedDict``s: at runtime each chunk is a plain ``dict`` (zero

--- a/tests/test_async_client.py
+++ b/tests/test_async_client.py
@@ -24,16 +24,6 @@ def _sse(*objs) -> bytes:
     return "".join(f"data: {json.dumps(o)}\n\n" for o in objs).encode()
 
 
-def _mcp_tool_response(result_dict: dict) -> dict:
-    return {
-        "jsonrpc": "2.0",
-        "id": 1,
-        "result": {
-            "content": [{"type": "text", "text": json.dumps(result_dict)}],
-        },
-    }
-
-
 # ---------------------------------------------------------------------------
 # construction
 # ---------------------------------------------------------------------------
@@ -52,26 +42,6 @@ async def test_async_client_stores_token():
 async def test_async_client_context_manager():
     async with AsyncSuperMeClient(api_key="tok") as client:
         assert client.token == "tok"
-
-
-# ---------------------------------------------------------------------------
-# ask_my_agent (non-streaming)
-# ---------------------------------------------------------------------------
-
-
-@respx.mock
-async def test_ask_my_agent_returns_dict():
-    respx.post(f"{MCP_BASE}/mcp/").mock(
-        return_value=httpx.Response(
-            200,
-            json=_mcp_tool_response(
-                {"response": "Great question!", "conversation_id": "c1"}
-            ),
-        )
-    )
-    async with AsyncSuperMeClient(api_key="tok") as client:
-        result = await client.ask_my_agent("What is PMF?")
-    assert result["response"] == "Great question!"
 
 
 # ---------------------------------------------------------------------------
@@ -186,7 +156,7 @@ async def test_async_client_mcp_error_raises():
     )
     async with AsyncSuperMeClient(api_key="tok") as client:
         with pytest.raises(MCPError, match="MCP error -32600"):
-            await client.ask_my_agent("hi")
+            await client.get_user_details("someone")
 
 
 # ---------------------------------------------------------------------------
@@ -205,5 +175,3 @@ async def test_live_get_agentic_resume(async_live_client):
 async def test_live_stream_interview_list(async_live_client):
     interviews = await async_live_client.list_my_interviews()
     assert isinstance(interviews, list)
-
-

--- a/tests/test_live.py
+++ b/tests/test_live.py
@@ -80,19 +80,6 @@ def test_live_ask_conversation_continuity(live_client, live_username):
 
 
 # ---------------------------------------------------------------------------
-# Ask my agent
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.live
-def test_live_ask_my_agent(live_client):
-    result = live_client.ask_my_agent("Say hello in one sentence.")
-    assert isinstance(result, dict)
-    assert "response" in result or "answer" in result or "content" in result
-    assert "conversation_id" in result
-
-
-# ---------------------------------------------------------------------------
 # Low-level MCP access
 # ---------------------------------------------------------------------------
 

--- a/tests/test_partner_streaming.py
+++ b/tests/test_partner_streaming.py
@@ -1,4 +1,4 @@
-"""Tests for partner SSE streaming (ask(stream=True), ask_my_agent(stream=True)) and the
+"""Tests for partner SSE streaming (ask(stream=True)) and the
 resource-backed conversation reads + user_details_read. Unit (mocked) only."""
 
 from __future__ import annotations
@@ -62,9 +62,8 @@ def _rpc_resource(payload) -> httpx.Response:
 
 
 def test_streaming_methods_exist():
-    for name in ("ask", "ask_my_agent"):
-        assert callable(getattr(SuperMeClient, name))
-        assert callable(getattr(AsyncSuperMeClient, name))
+    assert callable(getattr(SuperMeClient, "ask"))
+    assert callable(getattr(AsyncSuperMeClient, "ask"))
 
 
 def test_get_user_details_exists():
@@ -144,85 +143,6 @@ class TestAskStream:
 
 
 # ---------------------------------------------------------------------------
-# ask_my_agent(stream=True) → /partner/agent
-# ---------------------------------------------------------------------------
-
-
-class TestAskMyAgentStream:
-    # /partner/agent has two wire eras. Backend PR #5643 translates internal
-    # turn events into the thin PartnerStreamChunk contract (content/tool/done/
-    # error) — the documented shape, see ``test_stops_after_thin_done_chunk``.
-    # Before #5643 deploys it still emits raw turn-lifecycle events; the tests
-    # below pin that the SDK terminates correctly against that legacy shape too
-    # (AGENT_TERMINAL is the union of both, so neither era hangs).
-    @respx.mock
-    def test_posts_to_partner_agent_and_yields_turn_events(self):
-        route = respx.post(f"{PARTNER_BASE}/partner/agent").mock(
-            return_value=httpx.Response(
-                200,
-                content=_sse(
-                    {"type": "turn_started", "conversation_id": "c1", "turn_id": "t1"},
-                    {"type": "content", "conversation_id": "c1", "content": "hi"},
-                    {
-                        "type": "turn_completed",
-                        "conversation_id": "c1",
-                        "turn_id": "t1",
-                    },
-                ),
-                headers={"content-type": "text/event-stream"},
-            )
-        )
-        with SuperMeClient(api_key=FAKE_JWT) as client:
-            events = list(client.ask_my_agent("summarise", stream=True))
-
-        body = json.loads(route.calls[0].request.content)
-        assert body["question"] == "summarise"
-        assert body["stream"] is True
-        assert [e["type"] for e in events][-1] == "turn_completed"
-
-    @respx.mock
-    def test_stops_after_turn_failed(self):
-        respx.post(f"{PARTNER_BASE}/partner/agent").mock(
-            return_value=httpx.Response(
-                200,
-                content=_sse(
-                    {"type": "turn_failed", "conversation_id": "c1", "error": "x"},
-                    {"type": "content", "conversation_id": "c1", "content": "nope"},
-                ),
-                headers={"content-type": "text/event-stream"},
-            )
-        )
-        with SuperMeClient(api_key=FAKE_JWT) as client:
-            events = list(client.ask_my_agent("hi", stream=True))
-        assert len(events) == 1
-        assert events[0]["type"] == "turn_failed"
-
-    @respx.mock
-    def test_stops_after_thin_done_chunk(self):
-        # Post-#5643: /partner/agent emits the thin done/error contract — the
-        # stream must stop on `done` and not hang past it.
-        respx.post(f"{PARTNER_BASE}/partner/agent").mock(
-            return_value=httpx.Response(
-                200,
-                content=_sse(
-                    {"type": "tool", "label": "Searching the web"},
-                    {"type": "content", "text": "hi"},
-                    {"type": "done", "conversation_id": "c1"},
-                    {"type": "content", "text": "after"},
-                ),
-                headers={"content-type": "text/event-stream"},
-            )
-        )
-        with SuperMeClient(api_key=FAKE_JWT) as client:
-            events = list(client.ask_my_agent("hi", stream=True))
-        assert [e["type"] for e in events] == ["tool", "content", "done"]
-        # PartnerStreamChunk field shapes, matching backend #5643's translator.
-        assert events[0]["label"] == "Searching the web"
-        assert events[1]["text"] == "hi"
-        assert events[2]["conversation_id"] == "c1"
-
-
-# ---------------------------------------------------------------------------
 # async streaming
 # ---------------------------------------------------------------------------
 
@@ -244,24 +164,6 @@ class TestAsyncStreaming:
         async with AsyncSuperMeClient(api_key=FAKE_JWT) as client:
             chunks = [c async for c in client.ask("hi", username="ludo", stream=True)]
         assert [c["type"] for c in chunks] == ["content", "done"]
-
-    @pytest.mark.asyncio
-    @respx.mock
-    async def test_async_agent_stream_stops_at_terminal(self):
-        respx.post(f"{PARTNER_BASE}/partner/agent").mock(
-            return_value=httpx.Response(
-                200,
-                content=_sse(
-                    {"type": "content", "conversation_id": "c1", "content": "x"},
-                    {"type": "turn_completed", "conversation_id": "c1"},
-                    {"type": "content", "conversation_id": "c1", "content": "after"},
-                ),
-                headers={"content-type": "text/event-stream"},
-            )
-        )
-        async with AsyncSuperMeClient(api_key=FAKE_JWT) as client:
-            events = [e async for e in client.ask_my_agent("hi", stream=True)]
-        assert [e["type"] for e in events] == ["content", "turn_completed"]
 
     @pytest.mark.asyncio
     @respx.mock

--- a/tests/test_workgroups.py
+++ b/tests/test_workgroups.py
@@ -53,23 +53,6 @@ def test_list_workgroups_empty():
 
 
 @respx.mock
-def test_get_workgroup_returns_dict():
-    _mock_mcp(GROUP)
-    client = SuperMeClient(api_key="tok")
-    result = client.get_workgroup("wg_abc")
-    assert result == GROUP
-    client.close()
-
-
-@respx.mock
-def test_get_workgroup_returns_none_on_error():
-    _mock_mcp({"error": "Workgroup not found: wg_missing"})
-    client = SuperMeClient(api_key="tok")
-    assert client.get_workgroup("wg_missing") is None
-    client.close()
-
-
-@respx.mock
 def test_create_workgroup_returns_group():
     route = _mock_mcp(GROUP)
     client = SuperMeClient(api_key="tok")

--- a/uv.lock
+++ b/uv.lock
@@ -600,7 +600,7 @@ wheels = [
 
 [[package]]
 name = "superme-sdk"
-version = "0.8.0"
+version = "0.9.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## What

The backend removed two surfaces the SDK still depended on. This PR **cuts** the now-broken SDK methods rather than repointing them at a workaround.

| Removed | Why it broke |
|---------|--------------|
| `ask_my_agent` (sync + async) | Its `stream=True` path posted to **`POST /partner/agent`**, deleted in backend #5712. Per the owner's call, the whole method was cut — not just the streaming path — even though the non-streaming MCP-tool path still worked. |
| `get_workgroup` (sync + async) | Called the **`workgroup_read`** MCP tool, removed in backend #5587 (10 → 7 tools). No read tool remains to repoint to. |
| `AGENT_TERMINAL` constant | Dead once the `/partner/agent` streaming path was gone. |

## Retained on purpose

- **`ask(stream=True)`** → `/partner/ask` is untouched and still works. `ASK_TERMINAL` stays (it drives that path).
- `PartnerStreamChunk` and the streaming type catalog stay — `ask` streaming still uses them.

## Also

- Updated `README.md`, `docs/api/streaming.md`, `docs/api/services/conversations.md`, and the `client.py` / `streaming.py` docstrings.
- Removed the now-dead tests; swapped one async error-path test onto `get_user_details`.
- Version **0.8.0 → 0.9.0** (breaking removal, pre-1.0 minor bump).

## How it slipped through

The SDK's own alignment PR (#60) merged ~9 min *before* backend #5587, so `workgroup_read` was left stale. The `/partner/agent` break is fresh from today's #5712. SDK tests are mocked (respx), so they encode the SDK's own assumed contract and don't catch backend drift.

## Verification

- 148 unit tests pass (30 live deselected)
- `ruff check` + `ruff format` clean on all changed files
- Repo-wide grep for every removed symbol returns zero hits
- Reviews (code / architecture / design): no Critical/Warning; design = no visual changes

---
[duy 🐨 563: another sdk and mcp check](https://duy.superme.koala.army/task/019f217b-117b-7990-8558-098d4b9f1563)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove `ask_my_agent` and `get_workgroup` methods from the SDK
> - Deletes `ask_my_agent` from both sync and async `ConversationsMixin`, removing the `/partner/agent` streaming path and the `ask_my_agent` MCP tool call fallback.
> - Deletes `get_workgroup` from both sync and async `WorkgroupsMixin`, removing the `workgroup_read` MCP tool call.
> - Consolidates terminal event constants into a single `ASK_TERMINAL` set that includes both current (`done`, `error`) and legacy turn lifecycle events (`turn_completed`, `turn_failed`, `turn_interrupted`); `AGENT_TERMINAL` is removed.
> - Bumps version from `0.8.0` to `0.9.0` and updates docs and tests to reflect only `ask(stream=True)` as the supported streaming surface.
> - Behavioral Change: callers using `client.ask_my_agent(...)` or `client.get_workgroup(...)` will get `AttributeError` after upgrading.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized da692d8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated streaming docs to focus on `ask(..., stream=True)` for sending questions to a user’s agent.
  * Clarified the expected streamed chunk types and when streams end.

* **Bug Fixes**
  * Removed outdated references to legacy agent-streaming wording from the docs and examples.
  * Simplified API references to match current behavior.

* **Chores**
  * Bumped the package version to `0.9.0`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->